### PR TITLE
Upgrade to Junit 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Java SDK to simplify connecting to [Smartsheet API](https://www.smarts
 
 ## System Requirements
 
-The SDK supports Java version 1.6 or later.
+The SDK supports Java 11 or later.
 
 ## Installation
 
@@ -131,13 +131,6 @@ If you would like to contribute a change to the SDK, please fork a branch and th
 ## Version Numbers
 
 Starting from v3.0.0 release, the Smartsheet Java SDK has been updated to Java 11.
-
-Starting from the v2.68.0 release, Smartsheet SDKs will use a new versioning strategy. Since all users are on the
-Smartsheet API 2.0, the SDK version numbers will start with 2. The 2nd number will be an internal reference number.
-The 3rd number is for incremental changes.
-
-For example, v2.68.0 means that you are using our 2.0 version of the API, the API is synced internally to a tag of 68,
-and then if there are numbers after the last decimal, that will indicate a minor change.
 
 ## Support
 

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -129,9 +129,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.5.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
 			<version>2.9.10.8</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.5.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -99,8 +99,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.1.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.9.5</version>
+			<version>5.1.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -334,7 +340,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<properties>
 						<rerunFailingTestsCount>2</rerunFailingTestsCount>
@@ -349,7 +355,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>2.22.2</version>
 				<executions>
 					<!--
 						Invokes both the integration-test and the verify goals of the

--- a/src/integration-test/java/AttachmentResourcesIT.java
+++ b/src/integration-test/java/AttachmentResourcesIT.java
@@ -21,13 +21,13 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.AttachmentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AttachmentResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
@@ -39,7 +39,7 @@ public class AttachmentResourcesIT extends ITResourcesImpl{
     long sheetAttachmentId;
     long attachmentWithVersionId;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/CellResourcesIT.java
+++ b/src/integration-test/java/CellResourcesIT.java
@@ -20,19 +20,19 @@
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CellResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/ColumnResourcesIT.java
+++ b/src/integration-test/java/ColumnResourcesIT.java
@@ -26,22 +26,22 @@ import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.Sheet;
 import com.smartsheet.api.models.enums.ColumnInclusion;
 import com.smartsheet.api.models.enums.ColumnType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ColumnResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
     Sheet newSheet;
     Column addedColumn;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/CommentResourcesIT.java
+++ b/src/integration-test/java/CommentResourcesIT.java
@@ -22,13 +22,13 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.Comment;
 import com.smartsheet.api.models.Discussion;
 import com.smartsheet.api.models.Sheet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CommentResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
@@ -36,7 +36,7 @@ public class CommentResourcesIT extends ITResourcesImpl{
     Discussion newDiscussion;
     Comment newComment;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/ContactResourcesIT.java
+++ b/src/integration-test/java/ContactResourcesIT.java
@@ -23,19 +23,19 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.Contact;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ContactResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
     String contactId;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/DiscussionResourcesIT.java
+++ b/src/integration-test/java/DiscussionResourcesIT.java
@@ -21,14 +21,14 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.DiscussionInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DiscussionResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
@@ -37,7 +37,7 @@ public class DiscussionResourcesIT extends ITResourcesImpl{
     Discussion newDiscussionSheet;
     Row row;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/EventResourcesIT.java
+++ b/src/integration-test/java/EventResourcesIT.java
@@ -22,26 +22,26 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.Event;
 import com.smartsheet.api.models.EventResult;
 import com.smartsheet.api.models.User;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EventResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
     User user;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }
 
-    @Ignore
+    @Disabled
     // TODO - need access token with Admin Level permissions for this test to work
     @Test
     public void testListEvents() throws SmartsheetException {

--- a/src/integration-test/java/FavoriteResourcesIT.java
+++ b/src/integration-test/java/FavoriteResourcesIT.java
@@ -21,21 +21,21 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.FavoriteType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class FavoriteResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/FolderResourcesIT.java
+++ b/src/integration-test/java/FolderResourcesIT.java
@@ -24,14 +24,14 @@ import com.smartsheet.api.models.enums.DestinationType;
 import com.smartsheet.api.models.enums.FolderCopyInclusion;
 import com.smartsheet.api.models.enums.FolderRemapExclusion;
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class FolderResourcesIT extends ITResourcesImpl {
@@ -42,7 +42,7 @@ public class FolderResourcesIT extends ITResourcesImpl {
     Folder newFolderWorkspace;
     Workspace workspace;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/GroupResourcesIT.java
+++ b/src/integration-test/java/GroupResourcesIT.java
@@ -20,16 +20,16 @@
 
 import com.smartsheet.api.*;
 import com.smartsheet.api.models.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class GroupResourcesIT extends ITResourcesImpl{
     static final String GROUP_NAME = "Test Group";
@@ -39,7 +39,7 @@ public class GroupResourcesIT extends ITResourcesImpl{
     long groupMemberId;
     PagedResult<Group> groups;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/HomeResourcesIT.java
+++ b/src/integration-test/java/HomeResourcesIT.java
@@ -21,20 +21,20 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.Home;
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class HomeResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/MultiPicklistIT.java
+++ b/src/integration-test/java/MultiPicklistIT.java
@@ -21,22 +21,22 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultiPicklistIT extends ITResourcesImpl {
     Smartsheet smartsheet;
     Sheet sheet;
     List<Column> addCols;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
 
@@ -50,7 +50,7 @@ public class MultiPicklistIT extends ITResourcesImpl {
         }
     }
 
-    @After
+    @AfterEach
     public void Teardown() throws Exception {
         smartsheet.sheetResources().deleteSheet(sheet.getId());
     }

--- a/src/integration-test/java/PassthroughResourcesIT.java
+++ b/src/integration-test/java/PassthroughResourcesIT.java
@@ -21,19 +21,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PassthroughResourcesIT extends ITResourcesImpl {
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/ReportResourcesIT.java
+++ b/src/integration-test/java/ReportResourcesIT.java
@@ -25,8 +25,8 @@ import com.smartsheet.api.models.enums.PaperSize;
 import com.smartsheet.api.models.enums.ReportInclusion;
 import com.smartsheet.api.models.enums.SheetEmailFormat;
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,13 +34,13 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReportResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
     private Long reportId = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
          smartsheet = createAuthentication();
 

--- a/src/integration-test/java/RowResourcesIT.java
+++ b/src/integration-test/java/RowResourcesIT.java
@@ -21,13 +21,13 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RowResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
@@ -37,7 +37,7 @@ public class RowResourcesIT extends ITResourcesImpl{
     Column addedColumn;
     Sheet copyToSheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/SearchResourcesIT.java
+++ b/src/integration-test/java/SearchResourcesIT.java
@@ -21,17 +21,17 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.SearchResult;
 import com.smartsheet.api.models.Sheet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SearchResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/ServerInfoIT.java
+++ b/src/integration-test/java/ServerInfoIT.java
@@ -20,17 +20,17 @@
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.ServerInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ServerInfoIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/ShareResourcesIT.java
+++ b/src/integration-test/java/ShareResourcesIT.java
@@ -22,8 +22,8 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.AccessLevel;
 import com.smartsheet.api.models.enums.ReportInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,8 +31,8 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ShareResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
@@ -44,7 +44,7 @@ public class ShareResourcesIT extends ITResourcesImpl{
     List<Share> reportShares = new ArrayList<Share>();
     List<Share> sheetShares = new ArrayList<Share>();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }
@@ -69,7 +69,7 @@ public class ShareResourcesIT extends ITResourcesImpl{
 
         if (reportsWrapper != null) {
             Report report = smartsheet.reportResources().getReport(reportsWrapper.getData().get(0).getId(), EnumSet.of(ReportInclusion.ATTACHMENTS, ReportInclusion.DISCUSSIONS), 1, 1);
-            assertNotNull("No reports to share", report);
+            assertNotNull(report, "No reports to share");
         }
 
         List<Share> reportShares = Arrays.asList(new Share.CreateUserShareBuilder().setEmailAddress("jane.doe@smartsheet.com").setAccessLevel(AccessLevel.EDITOR).build());
@@ -80,7 +80,7 @@ public class ShareResourcesIT extends ITResourcesImpl{
             reportShares = smartsheet.reportResources().shareResources().shareTo(8623082916079492L, reportShares, true);
             assertNotNull(reportShares);
         }
-        
+
         reportId = reportsWrapper.getData().get(0).getId();
     }
 

--- a/src/integration-test/java/SheetResourcesIT.java
+++ b/src/integration-test/java/SheetResourcesIT.java
@@ -22,14 +22,14 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.*;
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SheetResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
@@ -40,7 +40,7 @@ public class SheetResourcesIT extends ITResourcesImpl{
 
     Folder folder;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }
@@ -261,7 +261,7 @@ public class SheetResourcesIT extends ITResourcesImpl{
                 .build();
         SheetPublish newSheetPublish = smartsheet.sheetResources().updatePublishStatus(newSheetHome.getId(), sheetPublish);
 
-        assertTrue("read write show toolbar should be enabled", newSheetPublish.getReadWriteShowToolbar());
+        assertTrue(newSheetPublish.getReadWriteShowToolbar(), "read write show toolbar should be enabled");
     }
 
     public void testPublishSheet() throws SmartsheetException, IOException {
@@ -275,8 +275,8 @@ public class SheetResourcesIT extends ITResourcesImpl{
                 .build();
         SheetPublish newSheetPublish = smartsheet.sheetResources().updatePublishStatus(newSheetHome.getId(), sheetPublish);
 
-        assertFalse("read write show toolbar should not be enabled", newSheetPublish.getReadWriteShowToolbar());
-        assertFalse("read only full show toolbar should not be enabled", newSheetPublish.getReadOnlyFullShowToolbar());
+        assertFalse(newSheetPublish.getReadWriteShowToolbar(), "read write show toolbar should not be enabled");
+        assertFalse(newSheetPublish.getReadOnlyFullShowToolbar(), "read only full show toolbar should not be enabled");
     }
 
     public void testUpdatePublishStatus() throws SmartsheetException, IOException {

--- a/src/integration-test/java/SheetSummaryResourcesIT.java
+++ b/src/integration-test/java/SheetSummaryResourcesIT.java
@@ -21,9 +21,9 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,7 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SheetSummaryResourcesIT extends ITResourcesImpl {
 
@@ -39,7 +39,7 @@ public class SheetSummaryResourcesIT extends ITResourcesImpl {
     Sheet sheet;
     List<SummaryField> asf;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
 
@@ -53,7 +53,7 @@ public class SheetSummaryResourcesIT extends ITResourcesImpl {
         }
     }
 
-    @After
+    @AfterEach
     public void Teardown() throws Exception {
         smartsheet.sheetResources().deleteSheet(sheet.getId());
     }

--- a/src/integration-test/java/TemplateResourcesIT.java
+++ b/src/integration-test/java/TemplateResourcesIT.java
@@ -22,17 +22,17 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.Template;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TemplateResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/TokenResourcesIT.java
+++ b/src/integration-test/java/TokenResourcesIT.java
@@ -21,13 +21,13 @@
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.oauth.OAuthFlow;
 import com.smartsheet.api.oauth.OAuthFlowBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TokenResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/UserResourcesIT.java
+++ b/src/integration-test/java/UserResourcesIT.java
@@ -21,22 +21,22 @@
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class UserResourcesIT extends ITResourcesImpl{
     Smartsheet smartsheet;
     User user;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/integration-test/java/WorkspaceResourcesIT.java
+++ b/src/integration-test/java/WorkspaceResourcesIT.java
@@ -24,15 +24,15 @@ import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.AccessLevel;
 import com.smartsheet.api.models.enums.WorkspaceCopyInclusion;
 import com.smartsheet.api.models.enums.WorkspaceRemapExclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WorkspaceResourcesIT extends ITResourcesImpl{
 
@@ -40,7 +40,7 @@ public class WorkspaceResourcesIT extends ITResourcesImpl{
     long workspaceId;
     Workspace workspace;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         smartsheet = createAuthentication();
     }

--- a/src/test/java/com/smartsheet/api/AccessTokenExpiredExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/AccessTokenExpiredExceptionTest.java
@@ -21,14 +21,14 @@ package com.smartsheet.api;
  */
 
 import com.smartsheet.api.models.Error;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AccessTokenExpiredExceptionTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/HttpTestServer.java
+++ b/src/test/java/com/smartsheet/api/HttpTestServer.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -38,7 +38,7 @@ import java.io.InputStream;
 /**
  * A server for answering HTTP requests with test response data.
  */
-@Ignore
+@Disabled
 public class HttpTestServer {
     private Server _server;
     //private String _responseBody;

--- a/src/test/java/com/smartsheet/api/ResourceNotFoundExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/ResourceNotFoundExceptionTest.java
@@ -21,14 +21,14 @@ package com.smartsheet.api;
  */
 
 import com.smartsheet.api.models.Error;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResourceNotFoundExceptionTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/ServiceUnavailableExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/ServiceUnavailableExceptionTest.java
@@ -21,14 +21,14 @@ package com.smartsheet.api;
  */
 
 import com.smartsheet.api.models.Error;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ServiceUnavailableExceptionTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/SmartsheetBuilderTest.java
+++ b/src/test/java/com/smartsheet/api/SmartsheetBuilderTest.java
@@ -23,14 +23,14 @@ package com.smartsheet.api;
 import com.smartsheet.api.internal.SmartsheetImpl;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.internal.json.JacksonJsonSerializer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SmartsheetBuilderTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/SmartsheetExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/SmartsheetExceptionTest.java
@@ -21,45 +21,39 @@ package com.smartsheet.api;
  */
 
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class SmartsheetExceptionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-
-    @Before
-    public void setUp() throws Exception {
+    @Test
+    public void testSmartsheetExceptionString() {
+        Throwable throwable = assertThrows(SmartsheetException.class, () -> {
+            throw new SmartsheetException("My Exception");
+        });
+        assertEquals("My Exception", throwable.getMessage());
     }
 
     @Test
-    public void testSmartsheetExceptionString() throws SmartsheetException {
-        thrown.expect(SmartsheetException.class);
-        thrown.expectMessage("My Exception");
-        throw new SmartsheetException("My Exception");
+    public void testSmartsheetExceptionStringThrowable() {
+        NullPointerException cause = new NullPointerException();
+        Throwable throwable = assertThrows(SmartsheetException.class, () -> {
+            throw new SmartsheetException("Throwable exception", cause);
+        });
+        assertEquals("Throwable exception", throwable.getMessage());
+        assertEquals(cause, throwable.getCause());
     }
 
     @Test
-    public void testSmartsheetExceptionStringThrowable() throws SmartsheetException {
-        NullPointerException expected = new NullPointerException();
-        thrown.expect(SmartsheetException.class);
-        thrown.expectMessage("Throwable exception");
-        thrown.expectCause(is(expected));
-        throw new SmartsheetException("Throwable exception", expected);
-    }
-
-    @Test
-    public void testSmartsheetExceptionException() throws SmartsheetException {
-        NullPointerException expected = new NullPointerException();
-        thrown.expect(SmartsheetException.class);
-        thrown.expectCause(is(expected));
-        throw new SmartsheetException(expected);
+    public void testSmartsheetExceptionException() {
+        NullPointerException cause = new NullPointerException();
+        Throwable throwable = assertThrows(SmartsheetException.class, () -> {
+            throw new SmartsheetException(cause);
+        });
+        assertEquals(cause, throwable.getCause());
     }
 
 }

--- a/src/test/java/com/smartsheet/api/internal/AbstractResourcesTest.java
+++ b/src/test/java/com/smartsheet/api/internal/AbstractResourcesTest.java
@@ -24,9 +24,9 @@ import com.smartsheet.api.SmartsheetBuilder;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Home;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import java.util.Map;
 
 /**
@@ -48,11 +48,11 @@ public class AbstractResourcesTest {
         assertEquals(headers.get("Smartsheet-Change-Agent"), changeAgent);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createResourceWithObjectClassNull() throws SmartsheetException {
         AbstractResources resources = new AbstractResources(new SmartsheetImpl(SmartsheetBuilder.DEFAULT_BASE_URI, tokenValue,  new DefaultHttpClient(), null)) {};
         Home home = new Home();
 
-        resources.createResource("someValidPath", null, home);
+        assertThrows(IllegalArgumentException.class, () -> resources.createResource("someValidPath", null, home));
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/AttachmentVersioningResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/AttachmentVersioningResourcesImplTest.java
@@ -26,19 +26,19 @@ import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.AttachmentParentType;
 import com.smartsheet.api.models.enums.AttachmentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AttachmentVersioningResourcesImplTest extends ResourcesImplBase {
 
     private AttachmentVersioningResourcesImpl attachmentVersioningResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         attachmentVersioningResources = new AttachmentVersioningResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
                 new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
@@ -6,16 +6,16 @@ import com.smartsheet.api.models.Attachment;
 import com.smartsheet.api.models.enums.AttachmentParentType;
 import com.smartsheet.api.models.enums.AttachmentSubType;
 import com.smartsheet.api.models.enums.AttachmentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * #[license]
@@ -40,7 +40,7 @@ public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private  CommentAttachmentResourcesImpl commentAttachmentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         commentAttachmentResources = new CommentAttachmentResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/ContactResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ContactResourcesImplTest.java
@@ -25,19 +25,19 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Contact;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ContactResourcesImplTest extends ResourcesImplBase {
     ContactResourcesImpl contactResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         contactResources = new ContactResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
                 new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesImplTest.java
@@ -24,19 +24,19 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Attachment;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DiscussionAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private DiscussionAttachmentResourcesImpl discussionAttachmentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         discussionAttachmentResources = new DiscussionAttachmentResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesTest.java
@@ -21,19 +21,19 @@ package com.smartsheet.api.internal;
  */
 
 import com.smartsheet.api.internal.http.DefaultHttpClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DiscussionAttachmentResourcesTest extends ResourcesImplBase  {
 
     private DiscussionAttachmentResources discussionAttachmentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         discussionAttachmentResources = new DiscussionAttachmentResources(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/DiscussionCommentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionCommentResourcesImplTest.java
@@ -3,13 +3,13 @@ package com.smartsheet.api.internal;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Comment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
  * #[license]
@@ -34,7 +34,7 @@ public class DiscussionCommentResourcesImplTest extends ResourcesImplBase {
 
     private DiscussionCommentResourcesImpl discussionCommentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         discussionCommentResources = new DiscussionCommentResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/DiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionResourcesImplTest.java
@@ -23,20 +23,20 @@ package com.smartsheet.api.internal;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Comment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DiscussionResourcesImplTest extends ResourcesImplBase {
 
     private DiscussionResourcesImpl discussionResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         discussionResources = new DiscussionResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/FavoriteResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/FavoriteResourcesImplTest.java
@@ -25,21 +25,21 @@ import com.smartsheet.api.models.Favorite;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.FavoriteType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class FavoriteResourcesImplTest extends ResourcesImplBase {
     private FavoriteResourcesImpl favoriteResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         favoriteResources = new FavoriteResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/FolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/FolderResourcesImplTest.java
@@ -28,19 +28,19 @@ import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.DestinationType;
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FolderResourcesImplTest extends ResourcesImplBase {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // Create a folder resource
         folderResource = new FolderResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",

--- a/src/test/java/com/smartsheet/api/internal/GroupResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/GroupResourcesImplTest.java
@@ -28,22 +28,22 @@ import com.smartsheet.api.models.Group.UpdateGroupBuilder;
 import com.smartsheet.api.models.GroupMember;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupResourcesImplTest extends ResourcesImplBase {
 
     private GroupResourcesImpl groupResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         groupResources = new GroupResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/HomeFolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/HomeFolderResourcesImplTest.java
@@ -25,20 +25,20 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Folder;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HomeFolderResourcesImplTest extends ResourcesImplBase {
 
     private HomeFolderResourcesImpl homeFolderResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         homeFolderResources = new HomeFolderResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/HomeResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/HomeResourcesImplTest.java
@@ -27,8 +27,8 @@ import com.smartsheet.api.models.Home;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.Template;
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,13 +36,13 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HomeResourcesImplTest extends ResourcesImplBase {
 
     private HomeResourcesImpl homeResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         homeResources = new HomeResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
@@ -27,8 +27,8 @@ import com.smartsheet.api.models.enums.PaperSize;
 import com.smartsheet.api.models.enums.ReportInclusion;
 import com.smartsheet.api.models.enums.SheetEmailFormat;
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,13 +38,13 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReportResourcesImplTest extends ResourcesImplBase {
 
     private ReportResourcesImpl reportResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         reportResources = new ReportResourcesImpl(new SmartsheetImpl("http://localhost:9090/2.0/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/ResourcesImplBase.java
+++ b/src/test/java/com/smartsheet/api/internal/ResourcesImplBase.java
@@ -22,8 +22,8 @@ package com.smartsheet.api.internal;
 
 import com.smartsheet.api.HttpTestServer;
 import com.smartsheet.api.internal.json.JacksonJsonSerializer;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class ResourcesImplBase {
 
@@ -31,7 +31,7 @@ public class ResourcesImplBase {
     FolderResourcesImpl folderResource;
     JacksonJsonSerializer serializer;
 
-    @Before
+    @BeforeEach
     public void baseSetUp() throws Exception {
         // Setup test server
         server = new HttpTestServer();
@@ -42,7 +42,7 @@ public class ResourcesImplBase {
         JacksonJsonSerializer.setFailOnUnknownProperties(true);
     }
 
-    @After
+    @AfterEach
     public void baseTearDown() throws Exception {
         server.stop();
     }

--- a/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
@@ -8,16 +8,17 @@ import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.AttachmentParentType;
 import com.smartsheet.api.models.enums.AttachmentSubType;
 import com.smartsheet.api.models.enums.AttachmentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * #[license]
@@ -42,7 +43,7 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private  RowAttachmentResourcesImpl rowAttachmentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         rowAttachmentResources = new RowAttachmentResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));
@@ -98,11 +99,11 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
         assertEquals(AttachmentType.FILE, attachment.getAttachmentType());
     }
 
-    @Test(expected = SmartsheetException.class)
-    public void testAttachFileAsInputStreamWrongContentLength() throws SmartsheetException, IOException {
+    @Test
+    public void testAttachFileAsInputStreamWrongContentLength() throws IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);
-        rowAttachmentResources.attachFile(1234L, 345L, inputStream, "application/pdf", file.length() + 5, file.getName());
+        assertThrows(SmartsheetException.class, () -> rowAttachmentResources.attachFile(1234L, 345L, inputStream, "application/pdf", file.length() + 5, file.getName()));
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/RowColumnResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowColumnResourcesImplTest.java
@@ -5,14 +5,14 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.CellHistory;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /*
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 public class RowColumnResourcesImplTest extends ResourcesImplBase {
     private RowColumnResourcesImpl rowColumnResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         rowColumnResources = new RowColumnResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
                 new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
@@ -6,14 +6,14 @@ import com.smartsheet.api.models.Discussion;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.DiscussionInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * #[license]
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 public class RowDiscussionResourcesImplTest extends ResourcesImplBase {
 
     private RowDiscussionResourcesImpl discussionRowResources;
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         discussionRowResources = new RowDiscussionResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/SearchResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SearchResourcesImplTest.java
@@ -24,21 +24,22 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.SearchResult;
 import com.smartsheet.api.models.SearchResultItem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SearchResourcesImplTest  extends ResourcesImplBase  {
 
     private SearchResourcesImpl searchResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         searchResources = new SearchResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));
@@ -82,23 +83,23 @@ public class SearchResourcesImplTest  extends ResourcesImplBase  {
         assertEquals("SDK Code Checklist", results.get(0).getParentObjectName());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void nullQuerySearchSheet() throws SmartsheetException {
-        searchResources.searchSheet(1234L, null);
+    @Test
+    public void nullQuerySearchSheet() {
+        assertThrows(IllegalArgumentException.class, () -> searchResources.searchSheet(1234L, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void emptyQuerySearchSheet() throws SmartsheetException {
-        searchResources.searchSheet(1234L, "");
+    @Test
+    public void emptyQuerySearchSheet() {
+        assertThrows(IllegalArgumentException.class, () -> searchResources.searchSheet(1234L, ""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void nullQueryOnSeaerch() throws SmartsheetException {
-        searchResources.search(null);
+    @Test
+    public void nullQueryOnSeaerch() {
+        assertThrows(IllegalArgumentException.class, () -> searchResources.search(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void emptyQuerySearch() throws SmartsheetException {
-        searchResources.search("");
+    @Test
+    public void emptyQuerySearch() {
+        assertThrows(IllegalArgumentException.class, () -> searchResources.search(""));
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/ServerInfoResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ServerInfoResourcesImplTest.java
@@ -23,19 +23,19 @@ package com.smartsheet.api.internal;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.ServerInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerInfoResourcesImplTest extends ResourcesImplBase {
     private ServerInfoResourcesImpl serverInfoResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         serverInfoResources = new ServerInfoResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/ShareResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ShareResourcesImplTest.java
@@ -26,22 +26,23 @@ import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.Share;
 import com.smartsheet.api.models.enums.AccessLevel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShareResourcesImplTest extends ResourcesImplBase {
 
     private ShareResourcesImpl shareResourcesImpl;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         shareResourcesImpl = new ShareResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
                 new DefaultHttpClient(), serializer), "sheets");
@@ -57,10 +58,10 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
         server.setResponseBody(new File("src/test/resources/listShares.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);
         PagedResult<Share> shares = shareResourcesImpl.listShares(2906571706525572L, parameters, false);
-        assertTrue("The number of shares returned is incorrect.", shares.getTotalCount() == 2);
+        assertTrue(shares.getTotalCount() == 2, "The number of shares returned is incorrect.");
 
-        assertEquals("Email attribute of the share is incorrect.", "john.doe@smartsheet.com", shares.getData().get(0).getEmail());
-        assertEquals("Email attribute of the share is incorrect.",null, shares.getData().get(1).getEmail());
+        assertEquals("john.doe@smartsheet.com", shares.getData().get(0).getEmail(), "Email attribute of the share is incorrect.");
+        assertEquals(null, shares.getData().get(1).getEmail(), "Email attribute of the share is incorrect.");
     }
 
     @Test
@@ -83,9 +84,9 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
         assertEquals(share.getAccessLevel(), newShare.getAccessLevel());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testUpdateShareWithNullShare() throws SmartsheetException {
-        shareResourcesImpl.updateShare(123L, null);
+    @Test
+    public void testUpdateShareWithNullShare() {
+        assertThrows(IllegalArgumentException.class, () -> shareResourcesImpl.updateShare(123L, null));
     }
 
     @Test

--- a/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
@@ -8,15 +8,15 @@ import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.AttachmentParentType;
 import com.smartsheet.api.models.enums.AttachmentSubType;
 import com.smartsheet.api.models.enums.AttachmentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * #[license]
@@ -41,7 +41,7 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private SheetAttachmentResourcesImpl sheetAttachmentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         sheetAttachmentResources = new SheetAttachmentResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/SheetColumnResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetColumnResourcesImplTest.java
@@ -27,8 +27,8 @@ import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.enums.ColumnInclusion;
 import com.smartsheet.api.models.enums.ColumnType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,13 +36,13 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SheetColumnResourcesImplTest extends ResourcesImplBase {
 
     private SheetColumnResourcesImpl sheetColumnResourcesImpl;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         sheetColumnResourcesImpl = new SheetColumnResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/SheetCommentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetCommentResourcesImplTest.java
@@ -22,19 +22,19 @@ package com.smartsheet.api.internal;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Comment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SheetCommentResourcesImplTest extends ResourcesImplBase {
     private SheetCommentResourcesImpl sheetCommentResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception  {
         sheetCommentResources = new SheetCommentResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/SheetDiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetDiscussionResourcesImplTest.java
@@ -5,8 +5,8 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.DiscussionInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,7 +15,7 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * #[license]
@@ -41,7 +41,7 @@ public class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
 
     private SheetDiscussionResourcesImpl sheetDiscussionResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         sheetDiscussionResources = new SheetDiscussionResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
@@ -26,8 +26,8 @@ import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.*;
 import com.smartsheet.api.models.format.VerticalAlignment;
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,13 +35,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class SheetResourcesImplTest extends ResourcesImplBase {
     SheetResourcesImpl sheetResource;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // Create a folder resource
         sheetResource = new SheetResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
@@ -132,9 +132,9 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
 
         sheetResource.getSheetAsPDF(1234L, output, null);
 
-        assertNotNull("Downloaded PDF is null.",output);
-        assertTrue("Downloaded PDF is empty.", output.toByteArray().length > 0);
-        assertEquals("Downloaded PDF does not match the original size.",107906,output.toByteArray().length);
+        assertNotNull(output, "Downloaded PDF is null.");
+        assertTrue(output.toByteArray().length > 0, "Downloaded PDF is empty.");
+        assertEquals(107906,output.toByteArray().length, "Downloaded PDF does not match the original size.");
 
         //test a larger PDF
         file = new File("src/test/resources/large_sheet.pdf");
@@ -142,9 +142,9 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
         server.setContentType("application/pdf");
         output = new ByteArrayOutputStream();
         sheetResource.getSheetAsPDF(1234L, output, PaperSize.LEGAL);
-        assertNotNull("Downloaded PDF is null.", output);
-        assertTrue("Downloaded PDF is empty.", output.toByteArray().length > 0);
-        assertEquals("Downloaded PDF does not match the original size.",936995,output.toByteArray().length);
+        assertNotNull(output, "Downloaded PDF is null.");
+        assertTrue(output.toByteArray().length > 0, "Downloaded PDF is empty.");
+        assertEquals(936995,output.toByteArray().length, "Downloaded PDF does not match the original size.");
     }
 
     @Test
@@ -266,7 +266,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
         Sheet sheet = new Sheet.UpdateSheetBuilder().setName("new name").build();
         Sheet newSheet = sheetResource.updateSheet(sheet);
 
-        assertEquals("Sheet update (rename) failed.", sheet.getName(), newSheet.getName());
+        assertEquals(sheet.getName(), newSheet.getName(), "Sheet update (rename) failed.");
     }
 
     @Test

--- a/src/test/java/com/smartsheet/api/internal/SheetRowResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetRowResourcesImplTest.java
@@ -24,20 +24,20 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SheetRowResourcesImplTest extends ResourcesImplBase {
 
     private SheetRowResourcesImpl sheetRowResource;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         sheetRowResource = new SheetRowResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
                 new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/SightResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SightResourcesImplTest.java
@@ -22,21 +22,23 @@ package com.smartsheet.api.internal;
 
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class SightResourcesImplTest extends ResourcesImplBase {
     private SightResourcesImpl sightResourcesImpl;
 
-    @Before
+    @BeforeEach
     public void before() {
         sightResourcesImpl = new SightResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/", "accessToken",
             new DefaultHttpClient(), serializer));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void updateWithNullSight() throws SmartsheetException {
-        sightResourcesImpl.updateSight(null);
+    @Test
+    public void updateWithNullSight() {
+        assertThrows(IllegalArgumentException.class, () -> sightResourcesImpl.updateSight(null));
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
@@ -22,10 +22,10 @@ package com.smartsheet.api.internal;
 
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.internal.http.HttpClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SmartsheetImplTest extends ResourcesImplBase {
 
@@ -34,7 +34,7 @@ public class SmartsheetImplTest extends ResourcesImplBase {
     private final String baseURI = "http://localhost:9090/1.1/";
     private final String accessToken = "accessToken";
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         httpClient = new DefaultHttpClient();
         smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, serializer);

--- a/src/test/java/com/smartsheet/api/internal/TemplateResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/TemplateResourcesImplTest.java
@@ -26,20 +26,20 @@ import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.Template;
 import com.smartsheet.api.models.enums.AccessLevel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TemplateResourcesImplTest extends ResourcesImplBase {
 
     private TemplateResourcesImpl templateResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         templateResources = new TemplateResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/UserResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/UserResourcesImplTest.java
@@ -24,8 +24,8 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.UserStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,14 +33,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UserResourcesImplTest extends ResourcesImplBase {
 
     private UserResourcesImpl userResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         userResources = new UserResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/WorkspaceFolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/WorkspaceFolderResourcesImplTest.java
@@ -25,19 +25,19 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.models.Folder;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WorkspaceFolderResourcesImplTest extends ResourcesImplBase {
 
     private WorkspaceFolderResourcesImpl workspaceFolderResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         workspaceFolderResources = new WorkspaceFolderResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/WorkspaceResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/WorkspaceResourcesImplTest.java
@@ -26,21 +26,21 @@ import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.AccessLevel;
 import com.smartsheet.api.models.enums.DestinationType;
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class WorkspaceResourcesImplTest extends ResourcesImplBase {
 
     private WorkspaceResourcesImpl workspaceResources;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         workspaceResources = new WorkspaceResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
                 "accessToken", new DefaultHttpClient(), serializer));

--- a/src/test/java/com/smartsheet/api/internal/http/DefaultHttpClientTest.java
+++ b/src/test/java/com/smartsheet/api/internal/http/DefaultHttpClientTest.java
@@ -20,25 +20,24 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DefaultHttpClientTest {
     HttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         client = new DefaultHttpClient();
     }
-
-
 
     @Test
     public void testDefaultHttpClient() {}

--- a/src/test/java/com/smartsheet/api/internal/json/JSONSerializerExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/JSONSerializerExceptionTest.java
@@ -20,48 +20,46 @@ package com.smartsheet.api.internal.json;
  * %[license]
  */
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JSONSerializerExceptionTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
     @Test
-    public void testJSONSerializerExceptionString() throws JSONSerializerException {
-        thrown.expect(JSONSerializerException.class);
-        String message = "Test Exception";
-        thrown.expectMessage(message);
-        throw new JSONSerializerException(message);
+    public void testJSONSerializerExceptionString() {
+        Throwable throwable = assertThrows(JSONSerializerException.class, () -> {
+            throw new JSONSerializerException("Test Exception");
+        });
+        assertEquals("Test Exception", throwable.getMessage());
     }
 
 
 
     @Test
     public void testJSONSerializerExceptionStringThrowable() throws JSONSerializerException {
-        thrown.expect(JSONSerializerException.class);
-        String message = "Test Exception1";
-        thrown.expectMessage(message);
-        JSONSerializerException ex = new JSONSerializerException("test");
-        thrown.expectCause(is(ex));
-        throw new JSONSerializerException(message,ex);
+        NullPointerException cause = new NullPointerException();
+        Throwable throwable = assertThrows(JSONSerializerException.class, () -> {
+            throw new JSONSerializerException("Test Exception1", cause);
+        });
+        assertEquals("Test Exception1", throwable.getMessage());
+        assertEquals(cause, throwable.getCause());
+
+
     }
 
     @Test
     public void testJSONSerializerExceptionException() throws JSONSerializerException {
-        thrown.expect(JSONSerializerException.class);
-        JSONSerializerException ex = new JSONSerializerException("test");
-        thrown.expectCause(is(ex));
-        throw new JSONSerializerException(ex);
+        NullPointerException cause = new NullPointerException();
+        Throwable throwable = assertThrows(JSONSerializerException.class, () -> {
+            throw new JSONSerializerException(cause);
+        });
+        assertEquals(cause, throwable.getCause());
     }
 
 }

--- a/src/test/java/com/smartsheet/api/internal/json/JacksonJsonSerializerTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/JacksonJsonSerializerTest.java
@@ -26,19 +26,19 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.smartsheet.api.models.Folder;
 import com.smartsheet.api.models.Result;
 import com.smartsheet.api.models.User;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JacksonJsonSerializerTest {
     JacksonJsonSerializer jjs;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         jjs = new JacksonJsonSerializer();
     }
@@ -103,7 +103,7 @@ public class JacksonJsonSerializerTest {
         user1.setId(123L);
         user1.setEmail("test@test.com");
         try{
-            assertFalse("The id field should not be serialized. Instead the id is used in the url and not sent as part of the body.", jjs.serialize(user1).contains("id"));
+            assertFalse(jjs.serialize(user1).contains("id"), "The id field should not be serialized. Instead the id is used in the url and not sent as part of the body.");
         }catch(JSONSerializerException e){
             fail("Shouldn't throw an exception");
         }
@@ -169,7 +169,7 @@ public class JacksonJsonSerializerTest {
         User user = jjs.deserialize(User.class, new ByteArrayInputStream(b.toByteArray()));
 
         assertEquals(originalUser.getFirstName(), user.getFirstName());
-        assertNotEquals("The id was not deserialized into the User object.", originalUser.getId(), user.getId());
+        assertNotEquals(originalUser.getId(), user.getId(), "The id was not deserialized into the User object.");
     }
 
     @Test

--- a/src/test/java/com/smartsheet/api/internal/json/ObjectValueDeserializerTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/ObjectValueDeserializerTest.java
@@ -22,7 +22,7 @@ package com.smartsheet.api.internal.json;
 
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.ObjectValueType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -30,8 +30,8 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ObjectValueDeserializerTest {
     private static final double DELTA = 0.000001;
@@ -319,11 +319,11 @@ public class ObjectValueDeserializerTest {
         Map<String, Object> serializedMap = jacksonJsonSerializer.deserializeMap(new ByteArrayInputStream(json.getBytes()));
 
         for (ExpectedAttributeValue expectedAttribute : expected) {
-            assertTrue("Expected attribute '" + expectedAttribute.attributeName + "' in serialized object was missing!\n" + json, serializedMap.containsKey(expectedAttribute.attributeName));
-            assertEquals("Expected value for attribute '"+ expectedAttribute.attributeName +"'", expectedAttribute.attributeValue, serializedMap.get(expectedAttribute.attributeName));
+            assertTrue(serializedMap.containsKey(expectedAttribute.attributeName), "Expected attribute '" + expectedAttribute.attributeName + "' in serialized object was missing!\n" + json);
+            assertEquals(expectedAttribute.attributeValue, serializedMap.get(expectedAttribute.attributeName), "Expected value for attribute '"+ expectedAttribute.attributeName +"'");
         }
 
-        assertEquals("Number of serialized attributes did not equal the expected value.\n" + json, serializedMap.keySet().size(), expected.length);
+        assertEquals(serializedMap.keySet().size(), expected.length, "Number of serialized attributes did not equal the expected value.\n" + json);
     }
 
 

--- a/src/test/java/com/smartsheet/api/internal/oauth/OAuthFlowImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/oauth/OAuthFlowImplTest.java
@@ -29,9 +29,9 @@ import com.smartsheet.api.internal.json.JSONSerializerException;
 import com.smartsheet.api.internal.json.JacksonJsonSerializer;
 import com.smartsheet.api.internal.json.JsonSerializer;
 import com.smartsheet.api.oauth.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,8 +40,8 @@ import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OAuthFlowImplTest {
 
@@ -56,12 +56,12 @@ public class OAuthFlowImplTest {
 
     HttpTestServer server;
 
-    @After
+    @AfterEach
     public void baseTearDown() throws Exception {
         server.stop();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         oauth = new OAuthFlowImpl(clientId,clientSecret,redirectURL,authorizationURL,tokenURL, httpClient, json);
 

--- a/src/test/java/com/smartsheet/api/internal/util/DeleteUserParametersTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/DeleteUserParametersTest.java
@@ -21,9 +21,9 @@ package com.smartsheet.api.internal.util;
  */
 
 import com.smartsheet.api.models.DeleteUserParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DeleteUserParametersTest {
 

--- a/src/test/java/com/smartsheet/api/internal/util/QueryUtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/QueryUtilTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.internal.util;
  */
 
 import com.smartsheet.api.models.enums.ObjectInclusion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QueryUtilTest {
 

--- a/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
@@ -22,8 +22,8 @@ package com.smartsheet.api.internal.util;
 
 
 import org.apache.commons.io.input.CharSequenceInputStream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -46,13 +46,13 @@ public class StreamUtilTest {
             System.out.println("same stream returned (reset)");
             // verify readBytesFromStream gets everything from the inputStream (it also verifies cloneContent resets the source)
             byte[] streamBytes = StreamUtil.readBytesFromStream(inputStream);
-            Assert.assertArrayEquals(testBytes, streamBytes); // it's all US-ASCII so it should match UTF-8 bytes
+            Assertions.assertArrayEquals(testBytes, streamBytes); // it's all US-ASCII so it should match UTF-8 bytes
         } else {
             System.out.println("new stream returned");
             byte[] backupBytes = StreamUtil.readBytesFromStream(backupStream);
-            Assert.assertArrayEquals(testBytes, backupBytes);
+           Assertions.assertArrayEquals(testBytes, backupBytes);
         }
 
-        Assert.assertArrayEquals(testBytes, copyStream.toByteArray());
+       Assertions.assertArrayEquals(testBytes, copyStream.toByteArray());
     }
 }

--- a/src/test/java/com/smartsheet/api/logging/LoggingTest.java
+++ b/src/test/java/com/smartsheet/api/logging/LoggingTest.java
@@ -27,10 +27,10 @@ import com.smartsheet.api.Trace;
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.internal.json.JacksonJsonSerializer;
 import com.smartsheet.api.models.Sheet;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 
@@ -38,13 +38,13 @@ import java.io.ByteArrayOutputStream;
  *
  */
 public class LoggingTest {
-    @BeforeClass
+    @BeforeAll
     public static void dontFailOnUnrecongnizedFields() {
         // Setup the serializer
         JacksonJsonSerializer.setFailOnUnknownProperties(false);    // no idea why we enable this in ResourcesImplBase.baseSetup
     }
 
-    @AfterClass
+    @AfterAll
     public static void failOnUnrecongnizedFields() {
         // Setup the serializer
         JacksonJsonSerializer.setFailOnUnknownProperties(true);    // put it back the way we found it
@@ -57,21 +57,16 @@ public class LoggingTest {
         client.setTraces(Trace.Request, Trace.Response);    // should log entire request and response
         try {
             Sheet sheet = client.sheetResources().getSheet(42, null, null, null, null, null, 1, 1);
-            Assert.fail("expected SmartsheetException");
+           Assertions.fail("expected SmartsheetException");
         } catch (SmartsheetException expected) {
             String output = traceStream.toString();
             // not super-robust but asserts some of the important parts
-            Assert.assertTrue("request not found in - " + output,
-                    output.contains("\"request\" : {"));
-            Assert.assertTrue("Auth header not found in - " + output,
-                    output.contains("\"Authorization\" : \"Bearer ****null")); // truncated Auth header
-            Assert.assertTrue("response not found in - " + output,
-                    output.contains("\"response\" : {"));
-            Assert.assertTrue("response-body not found in - " + output,
-                    output.contains("\"body\" : \"{\\n  \\\"errorCode\\\" : 1002,\\n  \\\"message\\\" : " +
-                            "\\\"Your Access Token is invalid.\\\",\\n  \\\"refId\\\" :"));
-            Assert.assertTrue("status not found in - " + output,
-                    output.contains("\"status\" : \"HTTP/1.1 401 Unauthorized\""));
+           Assertions.assertTrue(output.contains("\"request\" : {"), "request not found in - " + output);
+           Assertions.assertTrue(output.contains("\"Authorization\" : \"Bearer ****null"), "Auth header not found in - " + output); // truncated Auth header
+           Assertions.assertTrue(output.contains("\"response\" : {"), "response not found in - " + output);
+           Assertions.assertTrue(output.contains("\"body\" : \"{\\n  \\\"errorCode\\\" : 1002,\\n  \\\"message\\\" : " +
+                            "\\\"Your Access Token is invalid.\\\",\\n  \\\"refId\\\" :"), "response-body not found in - " + output);
+           Assertions.assertTrue(output.contains("\"status\" : \"HTTP/1.1 401 Unauthorized\""), "status not found in - " + output);
         }
     }
 
@@ -83,16 +78,15 @@ public class LoggingTest {
         client.setTraces(Trace.Request, Trace.Response);    // should log entire request and response
         try {
             Sheet sheet = client.sheetResources().getSheet(42, null, null, null, null, null, 1, 1);
-            Assert.fail("expected SmartsheetException");
+           Assertions.fail("expected SmartsheetException");
         } catch (SmartsheetException expected) {
             String output = traceStream.toString();
             // not super-robust but asserts some of the important parts
-            Assert.assertTrue("request not found in - " + output, output.contains("request:{"));
-            Assert.assertTrue("Auth header not found in - " + output, output.contains("'Authorization':'Bearer ****ae05")); // truncated Auth header
-            Assert.assertTrue("response not found in - " + output, output.contains("response:{"));
-            Assert.assertTrue("response-body not found in - " + output,
-                    output.contains("body:'{\n  \"errorCode\" : 1002,\n  \"message\" : \"Your Access Token is invalid.\",\n  \"refId\" :"));
-            Assert.assertTrue("status not found in - " + output, output.contains("status:'HTTP/1.1 401 Unauthorized'"));
+           Assertions.assertTrue(output.contains("request:{"), "request not found in - " + output);
+           Assertions.assertTrue(output.contains("'Authorization':'Bearer ****ae05"), "Auth header not found in - " + output); // truncated Auth header
+           Assertions.assertTrue(output.contains("response:{"), "response not found in - " + output);
+           Assertions.assertTrue(output.contains("body:'{\n  \"errorCode\" : 1002,\n  \"message\" : \"Your Access Token is invalid.\",\n  \"refId\" :"), "response-body not found in - " + output);
+           Assertions.assertTrue(output.contains("status:'HTTP/1.1 401 Unauthorized'"), "status not found in - " + output);
         }
     }
 }

--- a/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
+++ b/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.AccessLevel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AccessLevelTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/AccessScopeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AccessScopeTest.java
@@ -21,12 +21,12 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.AccessScope;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AccessScopeTest {
 
@@ -59,9 +59,9 @@ public class AccessScopeTest {
         }
 
         for (com.smartsheet.api.oauth.AccessScope accessScope : com.smartsheet.api.oauth.AccessScope.values()) {
-            assertTrue("Verify '" + accessScope.name() + "' exists", scopeNames.contains(accessScope.name()));
+            assertTrue(scopeNames.contains(accessScope.name()), "Verify '" + accessScope.name() + "' exists");
         }
 
-        assertEquals("Verify lengths are the same", com.smartsheet.api.oauth.AccessScope.values().length, AccessScope.values().length);
+        assertEquals(com.smartsheet.api.oauth.AccessScope.values().length, AccessScope.values().length, "Verify lengths are the same");
     }
 }

--- a/src/test/java/com/smartsheet/api/models/AttachmentParentTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AttachmentParentTypeTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.AttachmentParentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AttachmentParentTypeTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/AttachmentSubTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AttachmentSubTypeTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.AttachmentSubType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AttachmentSubTypeTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/AttachmentTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AttachmentTypeTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.AttachmentType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AttachmentTypeTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/ColumnTagTest.java
+++ b/src/test/java/com/smartsheet/api/models/ColumnTagTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.ColumnTag;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ColumnTagTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/ColumnTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/ColumnTypeTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.ColumnType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ColumnTypeTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/IdentifiableModelTest.java
+++ b/src/test/java/com/smartsheet/api/models/IdentifiableModelTest.java
@@ -20,14 +20,14 @@ package com.smartsheet.api.models;
  * %[license]
  */
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IdentifiableModelTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/ObjectExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/ObjectExclusionTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.ObjectExclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ObjectExclusionTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/ObjectInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/ObjectInclusionTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.ObjectInclusion;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ObjectInclusionTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/PaginationParametersTest.java
+++ b/src/test/java/com/smartsheet/api/models/PaginationParametersTest.java
@@ -20,11 +20,11 @@ package com.smartsheet.api.models;
  * %[license]
  */
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PaginationParametersTest {
 

--- a/src/test/java/com/smartsheet/api/models/PaperSizeTest.java
+++ b/src/test/java/com/smartsheet/api/models/PaperSizeTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.PaperSize;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class PaperSizeTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/RecipientEmailTest.java
+++ b/src/test/java/com/smartsheet/api/models/RecipientEmailTest.java
@@ -20,9 +20,9 @@ package com.smartsheet.api.models;
  * %[license]
  */
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RecipientEmailTest {
 

--- a/src/test/java/com/smartsheet/api/models/RecipientGroupTest.java
+++ b/src/test/java/com/smartsheet/api/models/RecipientGroupTest.java
@@ -20,9 +20,9 @@ package com.smartsheet.api.models;
  * %[license]
  */
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RecipientGroupTest {
 

--- a/src/test/java/com/smartsheet/api/models/RowTest.java
+++ b/src/test/java/com/smartsheet/api/models/RowTest.java
@@ -21,17 +21,17 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.format.Format;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RowTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/SheetEmailFormatTest.java
+++ b/src/test/java/com/smartsheet/api/models/SheetEmailFormatTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.SheetEmailFormat;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SheetEmailFormatTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/SheetTest.java
+++ b/src/test/java/com/smartsheet/api/models/SheetTest.java
@@ -20,18 +20,18 @@ package com.smartsheet.api.models;
  * %[license]
  */
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SheetTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/SymbolTest.java
+++ b/src/test/java/com/smartsheet/api/models/SymbolTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.Symbol;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SymbolTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/SystemColumnTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/SystemColumnTypeTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.SystemColumnType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SystemColumnTypeTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/UserStatusTest.java
+++ b/src/test/java/com/smartsheet/api/models/UserStatusTest.java
@@ -21,15 +21,15 @@ package com.smartsheet.api.models;
  */
 
 import com.smartsheet.api.models.enums.UserStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class UserStatusTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/models/format/FormatTest.java
+++ b/src/test/java/com/smartsheet/api/models/format/FormatTest.java
@@ -22,19 +22,19 @@ package com.smartsheet.api.models.format;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FormatTest {
 
     @Mock
@@ -42,7 +42,7 @@ public class FormatTest {
     @Mock
     SerializerProvider provider;
 
-    @Before
+    @BeforeEach
     public void setup() {
 
     }
@@ -72,9 +72,9 @@ public class FormatTest {
             Format f = new Format(t.format);
             int i = 0;
             for (; i< t.output.length; i++) {
-                assertEquals("index " + i +" failed in " + t, t.output[i], f.formatArray[i]);
+                assertEquals(t.output[i], f.formatArray[i], "index " + i +" failed in " + t);
             }
-            assertTrue("Did not parse the correct amount: " + i, i >= ParserTests.EXPECTED_COUNT);
+            assertTrue(i >= ParserTests.EXPECTED_COUNT, "Did not parse the correct amount: " + i);
         }
     }
 
@@ -127,7 +127,7 @@ public class FormatTest {
     public void testFormatStringParsing(FormatTestCase<?>[] testCases) throws IOException {
         for (FormatTestCase test : testCases) {
             Format format = new Format(test.getFormat());
-            assertEquals ("Test case " + test, test.getExpected(), test.getResult(format));
+            assertEquals(test.getExpected(), test.getResult(format), "Test case " + test);
         }
     }
 
@@ -174,7 +174,7 @@ public class FormatTest {
         Format.FormatSerializer formatSerializer = new Format.FormatSerializer();
         formatSerializer.serialize(format, generator, provider);
         Mockito.verify(generator).writeString(expected);
-        Mockito.verifyZeroInteractions(provider);
+        Mockito.verifyNoInteractions(provider);
         Mockito.reset(generator, provider);
     }
 

--- a/src/test/java/com/smartsheet/api/oauth/OAuthTokenExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/oauth/OAuthTokenExceptionTest.java
@@ -20,14 +20,14 @@ package com.smartsheet.api.oauth;
  * %[license]
  */
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OAuthTokenExceptionTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/com/smartsheet/api/sdk_test/AutomationRulesTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/AutomationRulesTest.java
@@ -25,9 +25,9 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.AutomationActionFrequency;
 import com.smartsheet.api.models.enums.AutomationActionType;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class AutomationRulesTest {
         try {
             Smartsheet ss = HelperFunctions.SetupClient("List Automation Rules");
             PagedResult<AutomationRule> automationRules = ss.sheetResources().automationRuleResources().listAutomationRules(324, null);
-            Assert.assertEquals(2, (long)automationRules.getTotalCount());
+           Assertions.assertEquals(2, (long)automationRules.getTotalCount());
         } catch (Exception ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
         }
@@ -49,14 +49,14 @@ public class AutomationRulesTest {
         Smartsheet ss = HelperFunctions.SetupClient("Get Automation Rule");
         try {
             AutomationRule automationRule = ss.sheetResources().automationRuleResources().getAutomationRule(324, 284);
-            Assert.assertEquals(284, (long)automationRule.getId());
+           Assertions.assertEquals(284, (long)automationRule.getId());
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
         }
     }
 
-    @Ignore("awaiting API update to return Result object")
+    @Disabled("awaiting API update to return Result object")
     @Test
     public void UpdateAutomationRule() {
         Smartsheet ss = HelperFunctions.SetupClient("Update Automation Rule");

--- a/src/test/java/com/smartsheet/api/sdk_test/HelperFunctions.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/HelperFunctions.java
@@ -23,7 +23,7 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetBuilder;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class HelperFunctions {
 	public static Smartsheet SetupClient(String apiScenario){
@@ -37,6 +37,6 @@ public class HelperFunctions {
 		return ss;
 	}
 	public static void ExceptionMessage(String message, Throwable cause){
-		Assert.fail(String.format("Exception: %s Detail: %s", message, cause));
+		Assertions.fail(String.format("Exception: %s Detail: %s", message, cause));
 	}
 }

--- a/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
@@ -23,23 +23,22 @@ package com.smartsheet.api.sdk_test;
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class RowTest {
 
-	
+
 	@Test
 	public void ListSheets_NoParams()
 	{
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
 			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(null, null, null);
-			Assert.assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
+			Assertions.assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -73,7 +72,7 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1L, Arrays.asList(rowA,rowB));
 
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -98,9 +97,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(1, addedRows.get(0).getRowNumber().intValue());
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(1, addedRows.get(0).getRowNumber().intValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -126,9 +125,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(100, addedRows.get(0).getRowNumber().intValue());
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(100, addedRows.get(0).getRowNumber().intValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -162,8 +161,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
 
-			Assert.assertEquals(100, addedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(100, addedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -197,9 +196,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
 
-			Assert.assertEquals(10, addedRows.get(0).getId().intValue());
-			Assert.assertEquals(true, addedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(10, addedRows.get(0).getId().intValue());
+			Assertions.assertEquals(true, addedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -224,8 +223,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", addedRows.get(0).getCells().get(1).getFormula());
-			Assert.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", addedRows.get(0).getCells().get(1).getFormula());
+			Assertions.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -256,9 +255,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Google", addedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals("http://google.com", addedRows.get(0).getCells().get(0).getHyperlink().getUrl());
+			Assertions.assertEquals("Google", addedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals("http://google.com", addedRows.get(0).getCells().get(0).getHyperlink().getUrl());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -289,9 +288,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Sheet3", addedRows.get(0).getCells().get(1).getValue());
-			Assert.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assert.assertEquals(3L, addedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
+			Assertions.assertEquals("Sheet3", addedRows.get(0).getCells().get(1).getValue());
+			Assertions.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals(3L, addedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -322,9 +321,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Report8", addedRows.get(0).getCells().get(1).getValue());
-			Assert.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assert.assertEquals(8L, addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
+			Assertions.assertEquals("Report8", addedRows.get(0).getCells().get(1).getValue());
+			Assertions.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals(8L, addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -357,7 +356,7 @@ public class RowTest {
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assert.assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
+			Assertions.assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -383,7 +382,7 @@ public class RowTest {
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assert.assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
+			Assertions.assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -411,8 +410,8 @@ public class RowTest {
 
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(101L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assert.assertEquals("2FS +2.5d", addedRows.get(0).getCells().get(1).getValue());
+			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals("2FS +2.5d", addedRows.get(0).getCells().get(1).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -448,8 +447,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals("Apple", updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals("Apple", updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -485,8 +484,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals(100, updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(100, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -522,8 +521,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals(true, updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(true, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -549,8 +548,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", updatedRows.get(0).getCells().get(1).getFormula());
-			Assert.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", updatedRows.get(0).getCells().get(1).getFormula());
+			Assertions.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -582,9 +581,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Google", updatedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals("http://google.com", updatedRows.get(0).getCells().get(0).getHyperlink().getUrl());
+			Assertions.assertEquals("Google", updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals("http://google.com", updatedRows.get(0).getCells().get(0).getHyperlink().getUrl());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -616,9 +615,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Sheet3", updatedRows.get(0).getCells().get(1).getValue());
-			Assert.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assert.assertEquals(3L, updatedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
+			Assertions.assertEquals("Sheet3", updatedRows.get(0).getCells().get(1).getValue());
+			Assertions.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals(3L, updatedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -650,9 +649,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals("Report8", updatedRows.get(0).getCells().get(1).getValue());
-			Assert.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assert.assertEquals(8L, updatedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
+			Assertions.assertEquals("Report8", updatedRows.get(0).getCells().get(1).getValue());
+			Assertions.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
+			Assertions.assertEquals(8L, updatedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -686,7 +685,7 @@ public class RowTest {
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assert.assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
+			Assertions.assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -713,7 +712,7 @@ public class RowTest {
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assert.assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
+			Assertions.assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -734,8 +733,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -757,8 +756,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals(false, updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(false, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -781,9 +780,9 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(null, updatedRows.get(0).getCells().get(0).getHyperlink());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getHyperlink());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -806,9 +805,9 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assert.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
-			Assert.assertEquals(null, updatedRows.get(0).getCells().get(0).getLinkInFromCell());
+			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
+			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getLinkInFromCell());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -839,7 +838,7 @@ public class RowTest {
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assert.assertEquals("Only one of cell.hyperlink or cell.linkInFromCell may be non-null.", ex.getMessage());
+			Assertions.assertEquals("Only one of cell.hyperlink or cell.linkInFromCell may be non-null.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -857,8 +856,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(10L, updatedRows.get(0).getId().longValue());
-			Assert.assertEquals(1L, updatedRows.get(0).getRowNumber().longValue());
+			Assertions.assertEquals(10L, updatedRows.get(0).getId().longValue());
+			Assertions.assertEquals(1L, updatedRows.get(0).getRowNumber().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -877,8 +876,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(10L, updatedRows.get(0).getId().longValue());
-			Assert.assertEquals(100L, updatedRows.get(0).getRowNumber().longValue());
+			Assertions.assertEquals(10L, updatedRows.get(0).getId().longValue());
+			Assertions.assertEquals(100L, updatedRows.get(0).getRowNumber().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());

--- a/src/test/java/com/smartsheet/api/sdk_test/SheetTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/SheetTest.java
@@ -25,8 +25,8 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -41,7 +41,7 @@ public class SheetTest {
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
 			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(null, null, null);
-			Assert.assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
+			Assertions.assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -53,7 +53,7 @@ public class SheetTest {
 		try{
 			Smartsheet ss =  HelperFunctions.SetupClient("List Sheets - Include Owner Info");
 			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(EnumSet.of(SourceInclusion.OWNERINFO), null, null);
-			Assert.assertEquals("john.doe@smartsheet.com", sheets.getData().get(0).getOwner());
+			Assertions.assertEquals("john.doe@smartsheet.com", sheets.getData().get(0).getOwner());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -71,7 +71,7 @@ public class SheetTest {
 			ss.sheetResources().createSheet(sheetA);
 
 		}catch(SmartsheetException ex){
-			Assert.assertEquals("The new sheet requires either a fromId or columns.", ex.getMessage());
+			Assertions.assertEquals("The new sheet requires either a fromId or columns.", ex.getMessage());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());

--- a/src/test/java/com/smartsheet/api/sdk_test/SightsTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/SightsTest.java
@@ -24,9 +24,9 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 import com.smartsheet.api.models.enums.DestinationType;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 public class SightsTest {
 
@@ -35,7 +35,7 @@ public class SightsTest {
         try {
             Smartsheet ss = HelperFunctions.SetupClient("List Sights");
             PagedResult<Sight> sights = ss.sightResources().listSights(null, null);
-            Assert.assertEquals(6, (long)sights.getTotalCount());
+           Assertions.assertEquals(6, (long)sights.getTotalCount());
         } catch (Exception ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
         }
@@ -46,14 +46,14 @@ public class SightsTest {
         Smartsheet ss = HelperFunctions.SetupClient("Get Sight");
         try {
             Sight sight = ss.sightResources().getSight(52);
-            Assert.assertEquals(52, (long)sight.getId());
+           Assertions.assertEquals(52, (long)sight.getId());
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
         }
     }
 
-    @Ignore("destination types differ because of case")
+    @Disabled("destination types differ because of case")
     @Test
     public void CopySight() {
         Smartsheet ss = HelperFunctions.SetupClient("Copy Sight");
@@ -102,7 +102,7 @@ public class SightsTest {
         Smartsheet ss = HelperFunctions.SetupClient("Get Sight Publish Status");
         try {
             SightPublish publish = ss.sightResources().getPublishStatus(812L);
-            Assert.assertEquals(publish.getReadOnlyFullEnabled(), true);
+           Assertions.assertEquals(publish.getReadOnlyFullEnabled(), true);
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());


### PR DESCRIPTION
Starting to upgrade the test coverage in this repo. First step is updating to Junit 5 so that we can write better tests.

Most of the changes are pretty straightforward. The only ones worth noting are:
- Some assertions had error messages as an arg... the order of args flipped in Junit5 so that message is last instead of first
- The two Exception test classes used `@Rule` which doesn't exist in Junit5... upgraded those tests to a new way of testing