### PR TITLE
General test clean up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.24.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
 			<version>9.4.41.v20210516</version>

--- a/src/integration-test/java/AttachmentResourcesIT.java
+++ b/src/integration-test/java/AttachmentResourcesIT.java
@@ -45,7 +45,7 @@ public class AttachmentResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testAttachmentMethods() throws SmartsheetException, IOException {
+    void testAttachmentMethods() throws SmartsheetException, IOException {
         //smartsheet.setAssumedUser("ericyan99@gmail.com");
         //UserProfile user= smartsheet.userResources().getCurrentUser();
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObject());

--- a/src/integration-test/java/CellResourcesIT.java
+++ b/src/integration-test/java/CellResourcesIT.java
@@ -38,7 +38,7 @@ public class CellResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testGetCellHistory() throws SmartsheetException, IOException {
+    void testGetCellHistory() throws SmartsheetException, IOException {
         //create sheet
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObject());
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
@@ -56,7 +56,7 @@ public class CellResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testAddCellImage() throws SmartsheetException, IOException {
+    void testAddCellImage() throws SmartsheetException, IOException {
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObject());
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
 

--- a/src/integration-test/java/ColumnResourcesIT.java
+++ b/src/integration-test/java/ColumnResourcesIT.java
@@ -47,7 +47,7 @@ public class ColumnResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testColumnMethods() throws SmartsheetException, IOException {
+    void testColumnMethods() throws SmartsheetException, IOException {
         testAddColumn();
         testListColumns();
         testUpdateColumn();

--- a/src/integration-test/java/CommentResourcesIT.java
+++ b/src/integration-test/java/CommentResourcesIT.java
@@ -42,7 +42,7 @@ public class CommentResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testCommentMethods() throws SmartsheetException, IOException {
+    void testCommentMethods() throws SmartsheetException, IOException {
         testAddComment();
         testGetComment();
         testAddCommentWithAttachment();

--- a/src/integration-test/java/ContactResourcesIT.java
+++ b/src/integration-test/java/ContactResourcesIT.java
@@ -41,7 +41,7 @@ public class ContactResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testContactMethods() throws SmartsheetException, IOException {
+    void testContactMethods() throws SmartsheetException, IOException {
         testListContacts();
         testGetContact();
     }

--- a/src/integration-test/java/DiscussionResourcesIT.java
+++ b/src/integration-test/java/DiscussionResourcesIT.java
@@ -43,7 +43,7 @@ public class DiscussionResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testDiscussionMethods() throws SmartsheetException, IOException {
+    void testDiscussionMethods() throws SmartsheetException, IOException {
         testCreateDiscussionOnSheet();
         testCreateDiscussionOnRow();
         testGetRowDiscussions();

--- a/src/integration-test/java/EventResourcesIT.java
+++ b/src/integration-test/java/EventResourcesIT.java
@@ -44,7 +44,7 @@ public class EventResourcesIT extends ITResourcesImpl{
     @Disabled
     // TODO - need access token with Admin Level permissions for this test to work
     @Test
-    public void testListEvents() throws SmartsheetException {
+    void testListEvents() throws SmartsheetException {
 
         Date lastHour = new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1));
         EventResult eventResult = smartsheet.eventResources().listEvents(lastHour, null, 10, false);
@@ -78,7 +78,7 @@ public class EventResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testInvalidParams() {
+    void testInvalidParams() {
         try {
             EventResult eventResult = smartsheet.eventResources().listEvents(0, "2.1.0An4ZapaQaOXPdojlmediSZ1WqMdi5U_3l9gViOW7ic", 10, null);
             assertTrue(true);

--- a/src/integration-test/java/FavoriteResourcesIT.java
+++ b/src/integration-test/java/FavoriteResourcesIT.java
@@ -41,7 +41,7 @@ public class FavoriteResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testAddFavorites() throws SmartsheetException, IOException {
+    void testAddFavorites() throws SmartsheetException, IOException {
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObject());
         Folder folder = createFolder();
 
@@ -53,14 +53,14 @@ public class FavoriteResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testListFavorites() throws SmartsheetException {
+    void testListFavorites() throws SmartsheetException {
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
         PagedResult<Favorite> favorites = smartsheet.favoriteResources().listFavorites(parameters);
         assertNotNull(favorites);
     }
 
     @Test
-    public void testRemoveFavorites() throws Exception {
+    void testRemoveFavorites() throws Exception {
 
         Folder folder1= createFolder();
         Folder folder2= createFolder();
@@ -76,7 +76,7 @@ public class FavoriteResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testDeleteUser() throws IOException, SmartsheetException {
+    void testDeleteUser() throws IOException, SmartsheetException {
         DeleteUserParameters parameters = new DeleteUserParameters(12345L, true, true);
         //smartsheet.userResources().deleteUser(1234L, parameters);
     }

--- a/src/integration-test/java/FolderResourcesIT.java
+++ b/src/integration-test/java/FolderResourcesIT.java
@@ -48,7 +48,7 @@ public class FolderResourcesIT extends ITResourcesImpl {
     }
 
     @Test
-    public void testFolderMethods() throws IOException, SmartsheetException {
+    void testFolderMethods() throws IOException, SmartsheetException {
         testCreateFolderInHome();
         testListFoldersInHome();
         testCreateFolderInFolder();

--- a/src/integration-test/java/GroupResourcesIT.java
+++ b/src/integration-test/java/GroupResourcesIT.java
@@ -45,7 +45,7 @@ public class GroupResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testGroupMethods() throws SmartsheetException, IOException {
+    void testGroupMethods() throws SmartsheetException, IOException {
         removeExistingGroup();
         testCreateGroup();
         testListGroups();

--- a/src/integration-test/java/HomeResourcesIT.java
+++ b/src/integration-test/java/HomeResourcesIT.java
@@ -40,7 +40,7 @@ public class HomeResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testGetHome() throws SmartsheetException, IOException {
+    void testGetHome() throws SmartsheetException, IOException {
         List<Home> homes = new ArrayList<Home>();
         homes.add(smartsheet.homeResources().getHome(EnumSet.of(SourceInclusion.SOURCE)));
         homes.add(smartsheet.homeResources().getHome(null));

--- a/src/integration-test/java/MultiPicklistIT.java
+++ b/src/integration-test/java/MultiPicklistIT.java
@@ -56,7 +56,7 @@ public class MultiPicklistIT extends ITResourcesImpl {
     }
 
     @Test
-    public void testMultiPicklistMethods() throws SmartsheetException, IOException {
+    void testMultiPicklistMethods() throws SmartsheetException, IOException {
         testAddMultiPicklistColumn();
         testListMultiPicklistColumn();
         testAddMultiPicklistRow();

--- a/src/integration-test/java/PassthroughResourcesIT.java
+++ b/src/integration-test/java/PassthroughResourcesIT.java
@@ -39,7 +39,7 @@ public class PassthroughResourcesIT extends ITResourcesImpl {
     }
 
     @Test
-    public void testPassthroughMethods() throws SmartsheetException, IOException {
+    void testPassthroughMethods() throws SmartsheetException, IOException {
         Long id = 0L;
         String payload =
                 "{\"name\": \"my new sheet\"," +

--- a/src/integration-test/java/ReportResourcesIT.java
+++ b/src/integration-test/java/ReportResourcesIT.java
@@ -58,7 +58,7 @@ public class ReportResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testReportMethods() throws SmartsheetException, IOException {
+    void testReportMethods() throws SmartsheetException, IOException {
         testListReports();
         testGetReport();
         testGetReportAsExcel();

--- a/src/integration-test/java/RowResourcesIT.java
+++ b/src/integration-test/java/RowResourcesIT.java
@@ -43,7 +43,7 @@ public class RowResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testRowMethods() throws SmartsheetException, IOException {
+    void testRowMethods() throws SmartsheetException, IOException {
         testAddRows();
         testGetRow();
         testCopyRow();
@@ -91,7 +91,7 @@ public class RowResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testUpdateRows() throws SmartsheetException, IOException {
+    void testUpdateRows() throws SmartsheetException, IOException {
          //create sheet
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObject());
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
@@ -166,7 +166,7 @@ public class RowResourcesIT extends ITResourcesImpl{
 
 
     @Test
-    public void testPartialInsertRows() throws SmartsheetException, IOException {
+    void testPartialInsertRows() throws SmartsheetException, IOException {
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObjectWithAutoNumberColumn());
 
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
@@ -203,7 +203,7 @@ public class RowResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testPartialUpdateRows() throws SmartsheetException, IOException {
+    void testPartialUpdateRows() throws SmartsheetException, IOException {
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObjectWithAutoNumberColumn());
 
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();

--- a/src/integration-test/java/SearchResourcesIT.java
+++ b/src/integration-test/java/SearchResourcesIT.java
@@ -37,13 +37,13 @@ public class SearchResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testSearch() throws IOException, SmartsheetException {
+    void testSearch() throws IOException, SmartsheetException {
         SearchResult result = smartsheet.searchResources().search("aditi");
         assertNotNull(result.getResults());
     }
 
     @Test
-    public void testSearchSheet() throws IOException, SmartsheetException {
+    void testSearchSheet() throws IOException, SmartsheetException {
         //create sheet
         Sheet sheet = smartsheet.sheetResources().createSheet(createSheetObject());
 

--- a/src/integration-test/java/ServerInfoIT.java
+++ b/src/integration-test/java/ServerInfoIT.java
@@ -36,7 +36,7 @@ public class ServerInfoIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testGetServerInfo() throws SmartsheetException, IOException {
+    void testGetServerInfo() throws SmartsheetException, IOException {
         ServerInfo serverInfo = smartsheet.serverInfoResources().getServerInfo();
         assertNotNull(serverInfo.getFormats());
     }

--- a/src/integration-test/java/ShareResourcesIT.java
+++ b/src/integration-test/java/ShareResourcesIT.java
@@ -50,7 +50,7 @@ public class ShareResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testShareMethods() throws SmartsheetException, IOException{
+    void testShareMethods() throws SmartsheetException, IOException{
         //Commenting report sharing testing as report ID needs to be provided
         //testReportShareTo();
         testSheetShareTo();

--- a/src/integration-test/java/SheetResourcesIT.java
+++ b/src/integration-test/java/SheetResourcesIT.java
@@ -46,7 +46,7 @@ public class SheetResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testSheetMethods() throws SmartsheetException, IOException {
+    void testSheetMethods() throws SmartsheetException, IOException {
         testCreateSheetHome();
         testCopySheet();
         testMoveSheet();

--- a/src/integration-test/java/SheetSummaryResourcesIT.java
+++ b/src/integration-test/java/SheetSummaryResourcesIT.java
@@ -59,7 +59,7 @@ public class SheetSummaryResourcesIT extends ITResourcesImpl {
     }
 
     @Test
-    public void testSheetSummaryMethods() throws SmartsheetException, IOException {
+    void testSheetSummaryMethods() throws SmartsheetException, IOException {
         testAddSheetSummaryFields();
         testGetSheetSummary();
         testAddSheetSummaryFieldsWithPartialSuccess();

--- a/src/integration-test/java/TemplateResourcesIT.java
+++ b/src/integration-test/java/TemplateResourcesIT.java
@@ -38,7 +38,7 @@ public class TemplateResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testListPublicTemplates() throws IOException, SmartsheetException {
+    void testListPublicTemplates() throws IOException, SmartsheetException {
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
         PagedResult<Template> templates = smartsheet.templateResources().listPublicTemplates(null);
 
@@ -46,7 +46,7 @@ public class TemplateResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testListTemplates() throws IOException, SmartsheetException {
+    void testListTemplates() throws IOException, SmartsheetException {
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
         PagedResult<Template> templates = smartsheet.templateResources().listUserCreatedTemplates(parameters);
 

--- a/src/integration-test/java/TokenResourcesIT.java
+++ b/src/integration-test/java/TokenResourcesIT.java
@@ -33,7 +33,7 @@ public class TokenResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void tokenResources() throws Exception{
+    void tokenResources() throws Exception{
         //TODO
         OAuthFlow oAuthFlow = new OAuthFlowBuilder().setClientId("YOUR_CLIENT_ID").setRedirectURL("https://www.google.com").setClientSecret("YOUR_CLIENT_SECRET").build();
 

--- a/src/integration-test/java/UserResourcesIT.java
+++ b/src/integration-test/java/UserResourcesIT.java
@@ -42,20 +42,20 @@ public class UserResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testGetCurrentUser() throws SmartsheetException, IOException {
+    void testGetCurrentUser() throws SmartsheetException, IOException {
         UserProfile user = smartsheet.userResources().getCurrentUser();
         Account account = user.getAccount();
         assertNotNull(user);
     }
 
     @Test
-    public void testGetUser() throws SmartsheetException, IOException {
+    void testGetUser() throws SmartsheetException, IOException {
         UserProfile user = smartsheet.userResources().getUser(smartsheet.userResources().getCurrentUser().getId());
         assertNotNull(user);
     }
 
     @Test
-    public void testListUsers() throws SmartsheetException, IOException {
+    void testListUsers() throws SmartsheetException, IOException {
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
 
         PagedResult<User> userWrapper = smartsheet.userResources().listUsers(new HashSet(Arrays.asList("aditi.nioding@gmail.com")), parameters);
@@ -65,7 +65,7 @@ public class UserResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testAddProfileImage() throws SmartsheetException, IOException {
+    void testAddProfileImage() throws SmartsheetException, IOException {
         UserProfile me = smartsheet.userResources().getCurrentUser();
         assertNotNull(me);
         smartsheet.userResources().addProfileImage(me.getId(), "src/integration-test/resources/exclam.png", "image/png");
@@ -94,7 +94,7 @@ public class UserResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testListOrgSheets() throws SmartsheetException, IOException {
+    void testListOrgSheets() throws SmartsheetException, IOException {
         //PagedResult<Sheet> sheets = smartsheet.userResources().listOrgSheets();
         //not executed in test due to low permission
         //assertNotNull(sheets);

--- a/src/integration-test/java/WorkspaceResourcesIT.java
+++ b/src/integration-test/java/WorkspaceResourcesIT.java
@@ -46,7 +46,7 @@ public class WorkspaceResourcesIT extends ITResourcesImpl{
     }
 
     @Test
-    public void testWorkspaceMethods() throws IOException, SmartsheetException {
+    void testWorkspaceMethods() throws IOException, SmartsheetException {
         testCreateWorkspace();
         testCopyWorkspace();
         testShareWorkspace();

--- a/src/main/java/com/smartsheet/api/internal/util/Util.java
+++ b/src/main/java/com/smartsheet/api/internal/util/Util.java
@@ -22,7 +22,7 @@ package com.smartsheet.api.internal.util;
 
 public class Util {
 
-    public Util() {}
+    private Util() {}
 
     /** faster util method that avoids creation of array for single-arg cases */
     public static <T> T throwIfNull(T obj) {

--- a/src/test/java/com/smartsheet/api/AccessTokenExpiredExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/AccessTokenExpiredExceptionTest.java
@@ -26,14 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AccessTokenExpiredExceptionTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class AccessTokenExpiredExceptionTest {
 
     @Test
-    public void testAccessTokenExpiredException() {
+    void testAccessTokenExpiredException() {
         try{
             Error error = new Error();
             error.setErrorCode(1);

--- a/src/test/java/com/smartsheet/api/ResourceNotFoundExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/ResourceNotFoundExceptionTest.java
@@ -26,14 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ResourceNotFoundExceptionTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class ResourceNotFoundExceptionTest {
 
     @Test
-    public void testResourceNotFoundException() {
+    void testResourceNotFoundException() {
         try{
             Error error = new Error();
             error.setErrorCode(1);

--- a/src/test/java/com/smartsheet/api/ServiceUnavailableExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/ServiceUnavailableExceptionTest.java
@@ -26,14 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ServiceUnavailableExceptionTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class ServiceUnavailableExceptionTest {
 
     @Test
-    public void testServiceUnavailableException() {
+    void testServiceUnavailableException() {
         try{
             Error error = new Error();
             error.setErrorCode(1);

--- a/src/test/java/com/smartsheet/api/SmartsheetBuilderTest.java
+++ b/src/test/java/com/smartsheet/api/SmartsheetBuilderTest.java
@@ -28,22 +28,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SmartsheetBuilderTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class SmartsheetBuilderTest {
 
     @Test
-    public void testSmartsheetBuilder() {}
-
-    @Test
-    public void testSetHttpClient() {
-
-    }
-
-    @Test
-    public void testBuild() {
+    void testBuild() {
         Smartsheet smartsheet = new SmartsheetBuilder().build();
         assertTrue(smartsheet instanceof SmartsheetImpl);
 

--- a/src/test/java/com/smartsheet/api/SmartsheetExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/SmartsheetExceptionTest.java
@@ -28,9 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
-public class SmartsheetExceptionTest {
+class SmartsheetExceptionTest {
     @Test
-    public void testSmartsheetExceptionString() {
+    void testSmartsheetExceptionString() {
         Throwable throwable = assertThrows(SmartsheetException.class, () -> {
             throw new SmartsheetException("My Exception");
         });
@@ -38,7 +38,7 @@ public class SmartsheetExceptionTest {
     }
 
     @Test
-    public void testSmartsheetExceptionStringThrowable() {
+    void testSmartsheetExceptionStringThrowable() {
         NullPointerException cause = new NullPointerException();
         Throwable throwable = assertThrows(SmartsheetException.class, () -> {
             throw new SmartsheetException("Throwable exception", cause);
@@ -48,7 +48,7 @@ public class SmartsheetExceptionTest {
     }
 
     @Test
-    public void testSmartsheetExceptionException() {
+    void testSmartsheetExceptionException() {
         NullPointerException cause = new NullPointerException();
         Throwable throwable = assertThrows(SmartsheetException.class, () -> {
             throw new SmartsheetException(cause);

--- a/src/test/java/com/smartsheet/api/internal/AbstractResourcesTest.java
+++ b/src/test/java/com/smartsheet/api/internal/AbstractResourcesTest.java
@@ -32,12 +32,12 @@ import java.util.Map;
 /**
  * Created by kskeem on 3/1/16.
  */
-public class AbstractResourcesTest {
+class AbstractResourcesTest {
 
-    private String tokenValue = "somevalue";
-    private String changeAgent = "mychangeagent";
+    private final String tokenValue = "somevalue";
+    private final String changeAgent = "mychangeagent";
     @Test
-    public void testHeaders() {
+    void testHeaders() {
 
         SmartsheetImpl smartsheet = new SmartsheetImpl("doesnt/matter", tokenValue,  new DefaultHttpClient(), null);
         smartsheet.setChangeAgent(changeAgent);
@@ -49,7 +49,7 @@ public class AbstractResourcesTest {
     }
 
     @Test
-    public void createResourceWithObjectClassNull() throws SmartsheetException {
+    void createResourceWithObjectClassNull() {
         AbstractResources resources = new AbstractResources(new SmartsheetImpl(SmartsheetBuilder.DEFAULT_BASE_URI, tokenValue,  new DefaultHttpClient(), null)) {};
         Home home = new Home();
 

--- a/src/test/java/com/smartsheet/api/internal/AttachmentVersioningResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/AttachmentVersioningResourcesImplTest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AttachmentVersioningResourcesImplTest extends ResourcesImplBase {
+class AttachmentVersioningResourcesImplTest extends ResourcesImplBase {
 
     private AttachmentVersioningResourcesImpl attachmentVersioningResources;
 
@@ -46,14 +46,14 @@ public class AttachmentVersioningResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteAllVersions() throws SmartsheetException, IOException {
+    void testDeleteAllVersions() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteAttachment.json"));
 
         attachmentVersioningResources.deleteAllVersions(1234L, 5678L);
     }
 
     @Test
-    public void testListAllVersions() throws SmartsheetException, IOException {
+    void testListAllVersions() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listAttachmentVersions.json"));
 
         PaginationParameters parameters = new PaginationParameters(false, 1,1);
@@ -64,7 +64,7 @@ public class AttachmentVersioningResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachNewVersion() throws IOException, SmartsheetException  {
+    void testAttachNewVersion() throws IOException, SmartsheetException  {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         Attachment attachment = attachmentVersioningResources.attachNewVersion(1234L, 345L,file,

--- a/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
@@ -26,9 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
@@ -26,9 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,9 +36,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * limitations under the License.
  * %[license]
  */
-public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
+class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
 
-    private  CommentAttachmentResourcesImpl commentAttachmentResources;
+    private CommentAttachmentResourcesImpl commentAttachmentResources;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -47,7 +47,7 @@ public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachURL() throws SmartsheetException, IOException {
+    void testAttachURL() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachLink.json"));
 
         Attachment attachment = new Attachment();
@@ -62,7 +62,7 @@ public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testattachFile() throws SmartsheetException, IOException {
+    void testAttachFile() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         Attachment attachment = commentAttachmentResources.attachFile(1234L, 345L, file,
@@ -76,7 +76,7 @@ public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFileAsInputStream() throws SmartsheetException, IOException {
+    void testAttachFileAsInputStream() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);

--- a/src/test/java/com/smartsheet/api/internal/ContactResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ContactResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,8 +34,8 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ContactResourcesImplTest extends ResourcesImplBase {
-    ContactResourcesImpl contactResources;
+class ContactResourcesImplTest extends ResourcesImplBase {
+    private ContactResourcesImpl contactResources;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -44,17 +44,17 @@ public class ContactResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetContact() throws SmartsheetException, IOException {
+    void testGetContact() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getContact.json"));
         Contact contact = contactResources.getContact("xyz");
-        assertEquals(contact.getName(), "David Davidson");
+        assertEquals("David Davidson", contact.getName());
     }
 
     @Test
-    public void testListContacts() throws SmartsheetException, IOException {
+    void testListContacts() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listContacts.json"));
         PagedResult<Contact> contacts = contactResources.listContacts(new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build());
-        assertEquals(contacts.getData().get(0).getName(), "David Davidson");
+        assertEquals("David Davidson", contacts.getData().get(0).getName());
         assertTrue(contacts.getTotalCount() == 2);
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/ContactResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ContactResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesImplTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DiscussionAttachmentResourcesImplTest extends ResourcesImplBase {
+class DiscussionAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private DiscussionAttachmentResourcesImpl discussionAttachmentResources;
 
@@ -43,7 +43,7 @@ public class DiscussionAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetAttachments() throws SmartsheetException, IOException {
+    void testGetAttachments() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listAssociatedAttachments.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1,1);
 

--- a/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class DiscussionAttachmentResourcesTest extends ResourcesImplBase  {
+class DiscussionAttachmentResourcesTest extends ResourcesImplBase  {
 
     private DiscussionAttachmentResources discussionAttachmentResources;
 
@@ -40,7 +40,7 @@ public class DiscussionAttachmentResourcesTest extends ResourcesImplBase  {
     }
 
     @Test
-    public void testAttachFileLongFileString() {
+    void testAttachFileLongFileString() {
         try{
             discussionAttachmentResources.attachFile(1234L, new File("src/test/rescoures/getPDF.pdf"), "application/pdf");
             fail("Exception should have been thrown.");
@@ -50,7 +50,7 @@ public class DiscussionAttachmentResourcesTest extends ResourcesImplBase  {
     }
 
     @Test
-    public void testAttachFileLongFileStringLong(){
+    void testAttachFileLongFileStringLong(){
         try{
             discussionAttachmentResources.attachFile(1234L, new ByteArrayInputStream(new byte[]{}), "application/pdf", 1234L, "file.pdf");
             fail("Exception should have been thrown.");
@@ -58,8 +58,5 @@ public class DiscussionAttachmentResourcesTest extends ResourcesImplBase  {
             // Expected
         }
     }
-
-    @Test
-    public void testDiscussionAttachmentResources() {}
 
 }

--- a/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/DiscussionCommentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionCommentResourcesImplTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * limitations under the License.
  * %[license]
  */
-public class DiscussionCommentResourcesImplTest extends ResourcesImplBase {
+class DiscussionCommentResourcesImplTest extends ResourcesImplBase {
 
     private DiscussionCommentResourcesImpl discussionCommentResources;
 
@@ -41,7 +41,7 @@ public class DiscussionCommentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAddComment() throws SmartsheetException, IOException {
+    void testAddComment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/addDiscussionComment.json"));
 
         Comment comment = new Comment();
@@ -54,7 +54,7 @@ public class DiscussionCommentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAddCommentWithAttachment() throws SmartsheetException, IOException {
+    void testAddCommentWithAttachment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/addDiscussionComment.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         Comment comment = new Comment.AddCommentBuilder().setText("new comment").build();

--- a/src/test/java/com/smartsheet/api/internal/DiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/DiscussionResourcesImplTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DiscussionResourcesImplTest extends ResourcesImplBase {
+class DiscussionResourcesImplTest extends ResourcesImplBase {
 
     private DiscussionResourcesImpl discussionResources;
 
@@ -43,11 +43,7 @@ public class DiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDiscussionResourcesImpl() {
-    }
-
-    @Test
-    public void testAddDiscussionComment() throws SmartsheetException, IOException {
+    void testAddDiscussionComment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/addDiscussionComment.json"));
 
         Comment comment = new Comment();
@@ -60,7 +56,7 @@ public class DiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachments() {
+    void testAttachments() {
         assertNull(discussionResources.attachments());
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/FavoriteResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/FavoriteResourcesImplTest.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class FavoriteResourcesImplTest extends ResourcesImplBase {
+class FavoriteResourcesImplTest extends ResourcesImplBase {
     private FavoriteResourcesImpl favoriteResources;
 
     @BeforeEach
@@ -46,7 +46,7 @@ public class FavoriteResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAddFavorites() throws Exception {
+    void testAddFavorites() throws Exception {
         server.setResponseBody(new File("src/test/resources/addFavorites.json"));
         List<Favorite> favoritesToAdd = new Favorite.AddFavoriteBuilder().addFavorite(8400677765441412L, FavoriteType.SHEET).build();
         List < Favorite > addedfavorites = favoriteResources.addFavorites(favoritesToAdd);
@@ -54,7 +54,7 @@ public class FavoriteResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testListFavorites() throws Exception {
+    void testListFavorites() throws Exception {
         server.setResponseBody(new File("src/test/resources/listFavorites.json"));
         PaginationParameters parameters = new PaginationParameters(false,1,1);
         PagedResult<Favorite> favorites = favoriteResources.listFavorites(parameters);
@@ -63,7 +63,7 @@ public class FavoriteResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testRemoveFavorites() throws Exception {
+    void testRemoveFavorites() throws Exception {
         server.setResponseBody(new File("src/test/resources/removeFavorites.json"));
         Set<Long> folderIds = new HashSet<Long>();
         folderIds.add(123L);

--- a/src/test/java/com/smartsheet/api/internal/FolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/FolderResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@ import java.util.EnumSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FolderResourcesImplTest extends ResourcesImplBase {
+class FolderResourcesImplTest extends ResourcesImplBase {
 
     @BeforeEach
     public void setUp() {
@@ -48,11 +48,7 @@ public class FolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testFolderResourcesImpl() {
-    }
-
-    @Test
-    public void testGetFolder() throws SmartsheetException, IOException {
+    void testGetFolder() throws SmartsheetException, IOException {
 
         // Set a fake response
         server.setResponseBody(new File("src/test/resources/getFolder.json"));
@@ -67,7 +63,7 @@ public class FolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateFolder() throws SmartsheetException, IOException {
+    void testUpdateFolder() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateFolder.json"));
 
         Folder newFolder = new Folder.UpdateFolderBuilder().setName("New Name").build();
@@ -77,13 +73,13 @@ public class FolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteFolder() throws SmartsheetException, IOException {
+    void testDeleteFolder() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteFolder.json"));
         folderResource.deleteFolder(7752230582413188L);
     }
 
     @Test
-    public void testListFolders() throws SmartsheetException, IOException {
+    void testListFolders() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/listFolders.json"));
         PaginationParameters parameters = new PaginationParameters(true,1,1);
@@ -96,7 +92,7 @@ public class FolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateFolder() throws SmartsheetException, IOException {
+    void testCreateFolder() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createFolder.json"));
 
         Folder newFolder = new Folder.CreateFolderBuilder().setName("new folder by brett").build();
@@ -106,17 +102,17 @@ public class FolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCopyFolder() throws Exception {
+    void testCopyFolder() throws Exception {
         server.setResponseBody(new File("src/test/resources/copyFolder.json"));
         ContainerDestination containerDestination = new ContainerDestination();
         containerDestination.setDestinationType(DestinationType.FOLDER);
 
         Folder folder = folderResource.copyFolder(123L, containerDestination, null, null);
-        assertEquals(folder.getPermalink(), "https://{base_url}?lx=lB0JaOh6AX1wGwqxsQIMaA");
+        assertEquals("https://{base_url}?lx=lB0JaOh6AX1wGwqxsQIMaA", folder.getPermalink());
     }
 
     @Test
-    public void testMoveFolder() throws Exception {
+    void testMoveFolder() throws Exception {
         server.setResponseBody(new File("src/test/resources/moveFolder.json"));
         ContainerDestination containerDestination = new ContainerDestination();
         containerDestination.setDestinationType(DestinationType.FOLDER);

--- a/src/test/java/com/smartsheet/api/internal/FolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/FolderResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/GroupResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/GroupResourcesImplTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GroupResourcesImplTest extends ResourcesImplBase {
+class GroupResourcesImplTest extends ResourcesImplBase {
 
     private GroupResourcesImpl groupResources;
 
@@ -50,10 +50,7 @@ public class GroupResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testHomeResourcesImpl() {}
-
-    @Test
-    public void testGetGroups() throws SmartsheetException, IOException {
+    void testGetGroups() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listGroups.json"));
 
         PaginationParameters parameters = new PaginationParameters(false,1,1);
@@ -71,7 +68,7 @@ public class GroupResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetGroupById() throws SmartsheetException, IOException {
+    void testGetGroupById() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getGroup.json"));
 
         Group group =  groupResources.getGroup(123l);
@@ -93,7 +90,7 @@ public class GroupResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateGroup() throws SmartsheetException, IOException {
+    void testCreateGroup() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createGroup.json"));
 
         CreateGroupBuilder builder = new CreateGroupBuilder();
@@ -126,7 +123,7 @@ public class GroupResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateGroup() throws SmartsheetException, IOException {
+    void testUpdateGroup() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateGroup.json"));
 
         UpdateGroupBuilder builder = new UpdateGroupBuilder();
@@ -147,13 +144,13 @@ public class GroupResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteGroup() throws SmartsheetException, IOException {
+    void testDeleteGroup() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteGroup.json"));
         groupResources.deleteGroup(1234l);
     }
 
     @Test
-    public void testAddMembersToGroup() throws SmartsheetException, IOException {
+    void testAddMembersToGroup() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/addGroupMembers.json"));
         List<GroupMember> newMembers = new ArrayList<GroupMember>();
         newMembers.add(new GroupMember.AddGroupMemberBuilder().setEmail("test3@test.com").build());
@@ -167,7 +164,7 @@ public class GroupResourcesImplTest extends ResourcesImplBase {
         }
     }
     @Test
-    public void testRemoveMemberFromGroup() throws SmartsheetException, IOException {
+    void testRemoveMemberFromGroup() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteMemberFromGroup.json"));
         groupResources.memberResources().deleteGroupMember(1234l, 1234l);
     }

--- a/src/test/java/com/smartsheet/api/internal/HomeFolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/HomeFolderResourcesImplTest.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HomeFolderResourcesImplTest extends ResourcesImplBase {
+class HomeFolderResourcesImplTest extends ResourcesImplBase {
 
     private HomeFolderResourcesImpl homeFolderResources;
 
@@ -45,11 +45,7 @@ public class HomeFolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testHomeFolderResourcesImpl() {
-    }
-
-    @Test
-    public void testListFolders() throws SmartsheetException, IOException {
+    void testListFolders() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listFolders.json"));
 
         PaginationParameters parameters = new PaginationParameters(true, null, null);
@@ -62,7 +58,7 @@ public class HomeFolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateFolder() throws IOException, SmartsheetException {
+    void testCreateFolder() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/createFolders.json"));
 
         Folder folder = new Folder.CreateFolderBuilder().setName("Hello World").build();

--- a/src/test/java/com/smartsheet/api/internal/HomeResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/HomeResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class HomeResourcesImplTest extends ResourcesImplBase {
+class HomeResourcesImplTest extends ResourcesImplBase {
 
     private HomeResourcesImpl homeResources;
 
@@ -49,10 +49,7 @@ public class HomeResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testHomeResourcesImpl() {}
-
-    @Test
-    public void testGetHome() throws SmartsheetException, IOException {
+    void testGetHome() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getHome.json"));
 
         List<Home> homes = new ArrayList<Home>();
@@ -71,7 +68,7 @@ public class HomeResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testFolders() throws IOException, SmartsheetException {
+    void testFolders() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/getHomeFolders.json"));
 
         HomeFolderResources folders = homeResources.folderResources();

--- a/src/test/java/com/smartsheet/api/internal/HomeResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/HomeResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ReportResourcesImplTest extends ResourcesImplBase {
+class ReportResourcesImplTest extends ResourcesImplBase {
 
     private ReportResourcesImpl reportResources;
 
@@ -52,15 +52,15 @@ public class ReportResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetReport() throws SmartsheetException, IOException {
+    void testGetReport() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getReport.json"));
         Report report = reportResources.getReport(4583173393803140L, EnumSet.of(ReportInclusion.ATTACHMENTS, ReportInclusion.DISCUSSIONS), 1,1);
-        assertEquals(report.getPermalink(), "https://app.smartsheet.com/b/home?lx=pWNSDH9itjBXxBzFmyf-5w");
+        assertEquals("https://app.smartsheet.com/b/home?lx=pWNSDH9itjBXxBzFmyf-5w", report.getPermalink());
         assertTrue(report.getColumns().get(0).getVirtualId() == 4583173393803140L);
     }
 
     @Test
-    public void testSendSheet() throws Exception {
+    void testSendSheet() throws Exception {
         server.setResponseBody(new File("src/test/resources/sendEmails.json"));
 
         List<Recipient> recipients = new ArrayList<Recipient>();
@@ -84,7 +84,7 @@ public class ReportResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testListReports() throws  SmartsheetException, IOException {
+    void testListReports() throws  SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listReports.json"));
         PaginationParameters pagination = new PaginationParameters(true, null, null);
         PagedResult<Report> reportsWrapper = reportResources.listReports(pagination, null);
@@ -96,7 +96,7 @@ public class ReportResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetReportAsExcel() throws SmartsheetException, IOException{
+    void testGetReportAsExcel() throws SmartsheetException, IOException{
         File file = new File("src/test/resources/getExcel.xls");
         server.setResponseBody(file);
         server.setContentType("application/vnd.ms-excel");
@@ -112,7 +112,7 @@ public class ReportResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetReportAsCsv() throws SmartsheetException, IOException{
+    void testGetReportAsCsv() throws SmartsheetException, IOException{
         File file = new File("src/test/resources/getExcel.xls");
         server.setResponseBody(file);
         server.setContentType("text/csv");

--- a/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * limitations under the License.
  * %[license]
  */
-public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
+class RowAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private  RowAttachmentResourcesImpl rowAttachmentResources;
 
@@ -49,7 +49,7 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
                 "accessToken", new DefaultHttpClient(), serializer));
     }
     @Test
-    public void testAttachUrl() throws SmartsheetException, IOException {
+    void testAttachUrl() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachLink.json"));
 
         Attachment attachment = new Attachment();
@@ -64,7 +64,7 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetAttachments() throws SmartsheetException, IOException {
+    void testGetAttachments() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listAssociatedAttachments.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1,1);
 
@@ -74,7 +74,7 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFile() throws SmartsheetException, IOException {
+    void testAttachFile() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         Attachment attachment = rowAttachmentResources.attachFile(1234L, 345L, file,
@@ -88,7 +88,7 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFileAsInputStream() throws SmartsheetException, IOException {
+    void testAttachFileAsInputStream() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);
@@ -100,7 +100,7 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFileAsInputStreamWrongContentLength() throws IOException {
+    void testAttachFileAsInputStreamWrongContentLength() throws IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);

--- a/src/test/java/com/smartsheet/api/internal/RowColumnResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowColumnResourcesImplTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/RowColumnResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowColumnResourcesImplTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * limitations under the License.
  * %[license]
  */
-public class RowColumnResourcesImplTest extends ResourcesImplBase {
+class RowColumnResourcesImplTest extends ResourcesImplBase {
     private RowColumnResourcesImpl rowColumnResources;
 
     @BeforeEach
@@ -44,13 +44,13 @@ public class RowColumnResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetCellHistory() throws SmartsheetException, IOException {
+    void testGetCellHistory() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getCellHistory.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);
         PagedResult<CellHistory> cellHistory= rowColumnResources.getCellHistory(123L, 123L, 123L, parameters);
 
         assertTrue(cellHistory.getTotalPages() == 1);
-        assertEquals(cellHistory.getData().get(1).getModifiedBy().getName(), "Joe Smart");
+        assertEquals("Joe Smart", cellHistory.getData().get(1).getModifiedBy().getName());
     }
 
 }

--- a/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * limitations under the License.
  * %[license]
  */
-public class RowDiscussionResourcesImplTest extends ResourcesImplBase {
+class RowDiscussionResourcesImplTest extends ResourcesImplBase {
 
     private RowDiscussionResourcesImpl discussionRowResources;
     @BeforeEach
@@ -44,7 +44,7 @@ public class RowDiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateDiscussion() throws Exception {
+    void testCreateDiscussion() throws Exception {
         server.setResponseBody(new File("src/test/resources/createDiscussionOnRow.json"));
 
         Discussion discussion = new Discussion();
@@ -55,18 +55,18 @@ public class RowDiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateDiscussionWithAttachment() throws Exception {
+    void testCreateDiscussionWithAttachment() throws Exception {
         server.setResponseBody(new File("src/test/resources/createDiscussionOnRow.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         Comment comment = new Comment.AddCommentBuilder().setText("New comment").build();
         Discussion discussion = new Discussion.CreateDiscussionBuilder().setComment(comment).setTitle("Some title").build();
 
         Discussion newDiscussion = discussionRowResources.createDiscussionWithAttachment(123L, 456L, discussion, file, "application/pdf");
-        assertEquals(newDiscussion.getTitle(), "This is a new discussion");
+        assertEquals("This is a new discussion", newDiscussion.getTitle());
     }
 
     @Test
-    public void testListDiscussions() throws Exception {
+    void testListDiscussions() throws Exception {
         server.setResponseBody(new File("src/test/resources/getRowDiscussions.json"));
 
         Discussion discussion = new Discussion();

--- a/src/test/java/com/smartsheet/api/internal/SearchResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SearchResourcesImplTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SearchResourcesImplTest  extends ResourcesImplBase  {
+class SearchResourcesImplTest  extends ResourcesImplBase  {
 
     private SearchResourcesImpl searchResources;
 
@@ -46,11 +46,7 @@ public class SearchResourcesImplTest  extends ResourcesImplBase  {
     }
 
     @Test
-    public void testSearchResourcesImpl() {
-    }
-
-    @Test
-    public void testSearch() throws IOException, SmartsheetException {
+    void testSearch() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/search.json"));
 
         SearchResult result = searchResources.search("brett");
@@ -66,7 +62,7 @@ public class SearchResourcesImplTest  extends ResourcesImplBase  {
     }
 
     @Test
-    public void testSearchSheet() throws IOException, SmartsheetException {
+    void testSearchSheet() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/searchSheet.json"));
 
         SearchResult searchSheet = searchResources.searchSheet(1234L, "java");
@@ -84,22 +80,22 @@ public class SearchResourcesImplTest  extends ResourcesImplBase  {
     }
 
     @Test
-    public void nullQuerySearchSheet() {
+    void nullQuerySearchSheet() {
         assertThrows(IllegalArgumentException.class, () -> searchResources.searchSheet(1234L, null));
     }
 
     @Test
-    public void emptyQuerySearchSheet() {
+    void emptyQuerySearchSheet() {
         assertThrows(IllegalArgumentException.class, () -> searchResources.searchSheet(1234L, ""));
     }
 
     @Test
-    public void nullQueryOnSeaerch() {
+    void nullQueryOnSeaerch() {
         assertThrows(IllegalArgumentException.class, () -> searchResources.search(null));
     }
 
     @Test
-    public void emptyQuerySearch() {
+    void emptyQuerySearch() {
         assertThrows(IllegalArgumentException.class, () -> searchResources.search(""));
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/ServerInfoResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ServerInfoResourcesImplTest.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ServerInfoResourcesImplTest extends ResourcesImplBase {
+class ServerInfoResourcesImplTest extends ResourcesImplBase {
     private ServerInfoResourcesImpl serverInfoResources;
 
     @BeforeEach
@@ -43,7 +43,7 @@ public class ServerInfoResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetServerInfo() throws SmartsheetException, IOException {
+    void testGetServerInfo() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getServerInfo.json"));
         ServerInfo serverInfo = serverInfoResources.getServerInfo();
 

--- a/src/test/java/com/smartsheet/api/internal/ShareResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ShareResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ShareResourcesImplTest extends ResourcesImplBase {
+class ShareResourcesImplTest extends ResourcesImplBase {
 
     private ShareResourcesImpl shareResourcesImpl;
 
@@ -49,11 +49,7 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testShareResourcesImpl() {
-    }
-
-    @Test
-    public void testListShares() throws SmartsheetException, IOException {
+    void testListShares() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/listShares.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);
@@ -65,7 +61,7 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetShare() throws SmartsheetException, IOException {
+    void testGetShare() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getShare.json"));
 
         Share share = shareResourcesImpl.getShare(1234L, "fhqwhgads");
@@ -76,7 +72,7 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateShare() throws SmartsheetException, IOException {
+    void testUpdateShare() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateShare.json"));
         Share share = new Share();
         share.setAccessLevel(AccessLevel.ADMIN);
@@ -85,19 +81,19 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateShareWithNullShare() {
+    void testUpdateShareWithNullShare() {
         assertThrows(IllegalArgumentException.class, () -> shareResourcesImpl.updateShare(123L, null));
     }
 
     @Test
-    public void testDeleteShare() throws SmartsheetException, IOException {
+    void testDeleteShare() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteShare.json"));
 
         shareResourcesImpl.deleteShare(1234L, "fhqwhgads");
     }
 
     @Test
-    public void testShareTo() throws SmartsheetException, IOException {
+    void testShareTo() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/shareTo.json"));
 
         List<Share> shares = new ArrayList<Share>();
@@ -109,7 +105,7 @@ public class ShareResourcesImplTest extends ResourcesImplBase {
                 .setAccessLevel(AccessLevel.EDITOR).build());
 
         shares = shareResourcesImpl.shareTo(1234L, shares, true);
-        assertTrue(shares.size() == 1);
+        assertEquals(1, shares.size());
         assertEquals("jane.doe@smartsheet.com", shares.get(0).getEmail());
         assertEquals("Jane Doe", shares.get(0).getName());
     }

--- a/src/test/java/com/smartsheet/api/internal/ShareResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ShareResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * limitations under the License.
  * %[license]
  */
-public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
+class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
 
     private SheetAttachmentResourcesImpl sheetAttachmentResources;
 
@@ -48,14 +48,14 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteAttachment() throws SmartsheetException, IOException {
+    void testDeleteAttachment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteAttachment.json"));
 
         sheetAttachmentResources.deleteAttachment(1234L, 4567L);
     }
 
     @Test
-    public void testAttachUrl() throws SmartsheetException, IOException {
+    void testAttachUrl() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachLink.json"));
 
         Attachment attachment = new Attachment();
@@ -70,7 +70,7 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetAttachment() throws SmartsheetException, IOException {
+    void testGetAttachment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getAttachment.json"));
 
         Attachment attachment = sheetAttachmentResources.getAttachment(1234L, 345L);
@@ -79,7 +79,7 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testListAttachments() throws SmartsheetException, IOException {
+    void testListAttachments() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listAssociatedAttachments.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1,1);
 
@@ -89,7 +89,7 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFile() throws SmartsheetException, IOException {
+    void testAttachFile() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         Attachment attachment = sheetAttachmentResources.attachFile(1234L, file,
@@ -103,7 +103,7 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFileAsInputStream() throws SmartsheetException, IOException {
+    void testAttachFileAsInputStream() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);

--- a/src/test/java/com/smartsheet/api/internal/SheetColumnResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetColumnResourcesImplTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SheetColumnResourcesImplTest extends ResourcesImplBase {
+class SheetColumnResourcesImplTest extends ResourcesImplBase {
 
     private SheetColumnResourcesImpl sheetColumnResourcesImpl;
 
@@ -49,11 +49,7 @@ public class SheetColumnResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testSheetColumnResourcesImpl() {
-    }
-
-    @Test
-    public void testListColumns() throws SmartsheetException, IOException {
+    void testListColumns() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/listColumns.json"));
         PaginationParameters paginationParameters = new PaginationParameters(true, 1, 1);
@@ -68,7 +64,7 @@ public class SheetColumnResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAddColumn() throws SmartsheetException, IOException {
+    void testAddColumn() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/addColumn.json"));
         List<Column> columnsToCreate = new ArrayList<Column>();
 
@@ -80,7 +76,7 @@ public class SheetColumnResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateColumn() throws SmartsheetException, IOException {
+    void testUpdateColumn() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateColumn.json"));
 
         Column col = new Column();
@@ -104,13 +100,13 @@ public class SheetColumnResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteColumn() throws SmartsheetException, IOException {
+    void testDeleteColumn() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteColumn.json"));
         sheetColumnResourcesImpl.deleteColumn(123456789L, 987654321L);
     }
 
     @Test
-    public void testGetColumn() throws SmartsheetException, IOException {
+    void testGetColumn() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getColumn.json"));
         Column col = new Column();
         col.setIndex(2);

--- a/src/test/java/com/smartsheet/api/internal/SheetCommentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetCommentResourcesImplTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SheetCommentResourcesImplTest extends ResourcesImplBase {
+class SheetCommentResourcesImplTest extends ResourcesImplBase {
     private SheetCommentResourcesImpl sheetCommentResources;
 
     @BeforeEach
@@ -40,7 +40,7 @@ public class SheetCommentResourcesImplTest extends ResourcesImplBase {
                 "accessToken", new DefaultHttpClient(), serializer));
     }
     @Test
-    public void testGetComment() throws SmartsheetException, IOException {
+    void testGetComment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getComment.json"));
 
         Comment comment = sheetCommentResources.getComment(1234L, 1245L);
@@ -56,7 +56,7 @@ public class SheetCommentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteComment() throws SmartsheetException, IOException {
+    void testDeleteComment() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteComment.json"));
 
         sheetCommentResources.deleteComment(1234L, 2345L);

--- a/src/test/java/com/smartsheet/api/internal/SheetDiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetDiscussionResourcesImplTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * limitations under the License.
  * %[license]
  */
-public class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
+class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
 
 
     private SheetDiscussionResourcesImpl sheetDiscussionResources;
@@ -48,7 +48,7 @@ public class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateDiscussion() throws SmartsheetException, IOException {
+    void testCreateDiscussion() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createDiscussion.json"));
 
         // Test success
@@ -91,7 +91,7 @@ public class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateDiscussionWithAttachment() throws Exception {
+    void testCreateDiscussionWithAttachment() throws Exception {
         server.setResponseBody(new File("src/test/resources/createDiscussion.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         // Test success
@@ -134,7 +134,7 @@ public class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetDiscussion() throws SmartsheetException, IOException {
+    void testGetDiscussion() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getDiscussion.json"));
 
         Discussion discussion = sheetDiscussionResources.getDiscussion(1234L, 5678L);
@@ -149,14 +149,14 @@ public class SheetDiscussionResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteDiscussion() throws SmartsheetException, IOException {
+    void testDeleteDiscussion() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteDiscussion.json"));
 
         sheetDiscussionResources.deleteDiscussion(1234L, 2345L);
     }
 
     @Test
-    public void testGetAllDiscussions() throws SmartsheetException, IOException {
+    void testGetAllDiscussions() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getAllDiscussions.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);
 

--- a/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,8 +38,8 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-public class SheetResourcesImplTest extends ResourcesImplBase {
-    SheetResourcesImpl sheetResource;
+class SheetResourcesImplTest extends ResourcesImplBase {
+    private SheetResourcesImpl sheetResource;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -49,7 +49,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testListSheets() throws SmartsheetException, IOException {
+    void testListSheets() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/listSheets.json"));
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(false).setPageSize(1).setPage(1).build();
@@ -65,7 +65,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testListOrganizationSheets() throws SmartsheetException, IOException {
+    void testListOrganizationSheets() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/listSheets.json"));
         PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
@@ -74,7 +74,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetSheet() throws SmartsheetException, IOException {
+    void testGetSheet() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/getSheet.json"));
         Sheet sheet = sheetResource.getSheet(123123L, null, null, null, null, null, null, null);
@@ -95,7 +95,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetSheetWithFormat() throws SmartsheetException, IOException {
+    void testGetSheetWithFormat() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/getSheetWithFormat.json"));
         Sheet sheet = sheetResource.getSheet(123123L, null, null, null, null, null, null, null);
@@ -105,7 +105,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetSheetAsExcel() throws SmartsheetException, IOException {
+    void testGetSheetAsExcel() throws SmartsheetException, IOException {
         File file = new File("src/test/resources/getExcel.xls");
         server.setResponseBody(file);
         server.setContentType("application/vnd.ms-excel");
@@ -122,7 +122,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetSheetAsPDF() throws SmartsheetException, IOException {
+    void testGetSheetAsPDF() throws SmartsheetException, IOException {
 
         File file = new File("src/test/resources/getPDF.pdf");
         server.setResponseBody(file);
@@ -148,7 +148,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateSheet() throws SmartsheetException, IOException {
+    void testCreateSheet() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createSheet.json"));
 
         ArrayList<Column> list = new ArrayList<Column>();
@@ -167,7 +167,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateSheetFromTemplate() throws SmartsheetException, IOException {
+    void testCreateSheetFromTemplate() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/createSheetFromExisting.json"));
 
@@ -181,7 +181,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateSheetInFolder() throws SmartsheetException, IOException {
+    void testCreateSheetInFolder() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createSheet.json"));
 
         ArrayList<Column> list = new ArrayList<Column>();
@@ -204,7 +204,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateSheetInFolderFromTemplate() throws SmartsheetException, IOException {
+    void testCreateSheetInFolderFromTemplate() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/createSheetFromExisting.json"));
 
@@ -222,7 +222,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateSheetInWorkspace() throws SmartsheetException, IOException {
+    void testCreateSheetInWorkspace() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createSheet.json"));
 
         ArrayList<Column> list = new ArrayList<Column>();
@@ -238,7 +238,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateSheetInWorkspaceFromTemplate() throws SmartsheetException, IOException {
+    void testCreateSheetInWorkspaceFromTemplate() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/createSheetFromExisting.json"));
 
         Sheet sheet = new Sheet();
@@ -254,13 +254,13 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteSheet() throws SmartsheetException, IOException {
+    void testDeleteSheet() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteSheet.json"));
         sheetResource.deleteSheet(1234L);
     }
 
     @Test
-    public void testUpdateSheet() throws SmartsheetException, IOException {
+    void testUpdateSheet() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateSheet.json"));
 
         Sheet sheet = new Sheet.UpdateSheetBuilder().setName("new name").build();
@@ -270,7 +270,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetSheetVersion() throws SmartsheetException, IOException {
+    void testGetSheetVersion() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getSheetVersion.json"));
         int version = sheetResource.getSheetVersion(1234L);
         if (version != 1) {
@@ -279,7 +279,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testSendSheet() throws SmartsheetException, IOException {
+    void testSendSheet() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/sendEmails.json"));
 
         List<Recipient> recipients = new ArrayList<Recipient>();
@@ -303,27 +303,27 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testShares() {
+    void testShares() {
         sheetResource.shareResources();
     }
 
     @Test
-    public void testRows() {
+    void testRows() {
         sheetResource.rowResources();
     }
 
     @Test
-    public void testColumns() {
+    void testColumns() {
         sheetResource.columnResources();
     }
 
     @Test
-    public void testDiscussions() {
+    void testDiscussions() {
         sheetResource.discussionResources();
     }
 
     @Test
-    public void testGetPublishStatus() throws SmartsheetException, IOException {
+    void testGetPublishStatus() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getPublishStatus.json"));
 
         SheetPublish publishStatus = sheetResource.getPublishStatus(1234L);
@@ -336,7 +336,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdatePublishStatus() throws SmartsheetException, IOException {
+    void testUpdatePublishStatus() throws SmartsheetException, IOException {
 
         server.setResponseBody(new File("src/test/resources/setPublishStatus.json"));
 
@@ -358,17 +358,17 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCopySheet() throws SmartsheetException, IOException {
+    void testCopySheet() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/copySheet.json"));
         ContainerDestination containerDestination = new ContainerDestination();
         containerDestination.setDestinationType(DestinationType.FOLDER);
 
         Sheet sheet = sheetResource.copySheet(123L, containerDestination, null);
-        assertEquals(sheet.getName(), "newSheetName");
+        assertEquals("newSheetName", sheet.getName());
     }
 
     @Test
-    public void testMoveSheet() throws SmartsheetException, IOException {
+    void testMoveSheet() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/moveSheet.json"));
         ContainerDestination containerDestination = new ContainerDestination();
         containerDestination.setDestinationType(DestinationType.FOLDER);
@@ -377,7 +377,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetSheetAsCSV() throws SmartsheetException, IOException {
+    void testGetSheetAsCSV() throws SmartsheetException, IOException {
         File file = new File("src/test/resources/getCsv.csv");
         server.setResponseBody(file);
         server.setContentType("text/csv");
@@ -393,36 +393,36 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testShareResources() throws Exception {
+    void testShareResources() throws Exception {
 
     }
 
     @Test
-    public void testRowResources() throws Exception {
+    void testRowResources() throws Exception {
 
     }
 
     @Test
-    public void testColumnResources() throws Exception {
+    void testColumnResources() throws Exception {
 
     }
 
     @Test
-    public void testAttachmentResources() throws Exception {
+    void testAttachmentResources() throws Exception {
 
     }
 
     @Test
-    public void testDiscussionResources() throws Exception {
+    void testDiscussionResources() throws Exception {
 
     }
 
     @Test
-    public void testCommentResources() throws Exception {
+    void testCommentResources() throws Exception {
     }
 
     @Test
-    public void testCreateUpdateRequest() throws Exception {
+    void testCreateUpdateRequest() throws Exception {
         server.setResponseBody(new File("src/test/resources/createUpdateRequest.json"));
 
         List<Recipient> recipients = new ArrayList<Recipient>();
@@ -433,7 +433,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testSortSheet() throws Exception {
+    void testSortSheet() throws Exception {
         server.setResponseBody(new File("src/test/resources/getSheet.json"));
         SortSpecifier specifier = new SortSpecifier();
         SortCriterion criterion = new SortCriterion();
@@ -446,7 +446,7 @@ public class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCopyStream() throws Exception {
+    void testCopyStream() throws Exception {
 
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
@@ -393,35 +393,6 @@ class SheetResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    void testShareResources() throws Exception {
-
-    }
-
-    @Test
-    void testRowResources() throws Exception {
-
-    }
-
-    @Test
-    void testColumnResources() throws Exception {
-
-    }
-
-    @Test
-    void testAttachmentResources() throws Exception {
-
-    }
-
-    @Test
-    void testDiscussionResources() throws Exception {
-
-    }
-
-    @Test
-    void testCommentResources() throws Exception {
-    }
-
-    @Test
     void testCreateUpdateRequest() throws Exception {
         server.setResponseBody(new File("src/test/resources/createUpdateRequest.json"));
 
@@ -443,10 +414,5 @@ class SheetResourcesImplTest extends ResourcesImplBase {
         criteria.add(criterion);
         specifier.setSortCriteria(criteria);
         Sheet sheet = sheetResource.sortSheet(123L, specifier);
-    }
-
-    @Test
-    void testCopyStream() throws Exception {
-
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/SheetRowResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetRowResourcesImplTest.java
@@ -33,7 +33,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SheetRowResourcesImplTest extends ResourcesImplBase {
+class SheetRowResourcesImplTest extends ResourcesImplBase {
 
     private SheetRowResourcesImpl sheetRowResource;
 
@@ -44,10 +44,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testSheetRowResourcesImpl() {}
-
-    @Test
-    public void testInsertRows() throws SmartsheetException, IOException {
+    void testInsertRows() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/insertRows.json"));
 
         // Create a set of cells
@@ -78,7 +75,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetRow() throws SmartsheetException, IOException {
+    void testGetRow() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getRow.json"));
 
         Row row = sheetRowResource.getRow(1234L, 5678L, EnumSet.of(RowInclusion.COLUMNS, RowInclusion.FORMAT), EnumSet.of(ObjectExclusion.NONEXISTENT_CELLS));
@@ -91,7 +88,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testSendRows() throws SmartsheetException, IOException {
+    void testSendRows() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/sendRow.json"));
 
         RecipientEmail recipient = new RecipientEmail();
@@ -113,7 +110,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateRows() throws SmartsheetException, IOException {
+    void testUpdateRows() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateRows.json"));
 
         List<Row> rows = new ArrayList<Row>();
@@ -130,7 +127,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testMoveRows() throws SmartsheetException, IOException {
+    void testMoveRows() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/moveRow.json"));
         CopyOrMoveRowDirective copyOrMoveRowDirective = new CopyOrMoveRowDirective();
         CopyOrMoveRowDestination copyOrMoveRowDestination = new CopyOrMoveRowDestination();
@@ -144,7 +141,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCopyRows() throws SmartsheetException, IOException {
+    void testCopyRows() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/moveRow.json"));
         CopyOrMoveRowDirective copyOrMoveRowDirective = new CopyOrMoveRowDirective();
         CopyOrMoveRowDestination copyOrMoveRowDestination = new CopyOrMoveRowDestination();
@@ -158,7 +155,7 @@ public class SheetRowResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteRows() throws SmartsheetException, IOException {
+    void testDeleteRows() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/deleteRow.json"));
 
         Set<Long> rowIds = new HashSet<Long>();

--- a/src/test/java/com/smartsheet/api/internal/SightResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SightResourcesImplTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
-public class SightResourcesImplTest extends ResourcesImplBase {
+class SightResourcesImplTest extends ResourcesImplBase {
     private SightResourcesImpl sightResourcesImpl;
 
     @BeforeEach
@@ -38,7 +38,7 @@ public class SightResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void updateWithNullSight() {
+    void updateWithNullSight() {
         assertThrows(IllegalArgumentException.class, () -> sightResourcesImpl.updateSight(null));
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SmartsheetImplTest extends ResourcesImplBase {
+class SmartsheetImplTest extends ResourcesImplBase {
 
     private SmartsheetImpl smartsheet;
     private HttpClient httpClient;
@@ -39,93 +39,82 @@ public class SmartsheetImplTest extends ResourcesImplBase {
         httpClient = new DefaultHttpClient();
         smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, serializer);
     }
-
     @Test
-    public void testFinalize() {
-
-    }
-
-    @Test
-    public void testSmartsheetImpl() {
-
-    }
-
-    @Test
-    public void testGetHttpClient() {
+    void testGetHttpClient() {
         assertSame(httpClient, smartsheet.getHttpClient());
     }
 
     @Test
-    public void testGetJsonSerializer() {
+    void testGetJsonSerializer() {
         assertNotNull(smartsheet.getJsonSerializer());
     }
 
     @Test
-    public void testGetBaseURI() {
+    void testGetBaseURI() {
         assertEquals(baseURI, smartsheet.getBaseURI().toString());
     }
 
     @Test
-    public void testGetAssumedUser() {
+    void testGetAssumedUser() {
         assertNull(smartsheet.getAssumedUser());
     }
 
     @Test
-    public void testGetAccessToken() {
+    void testGetAccessToken() {
         assertEquals(accessToken, smartsheet.getAccessToken());
     }
 
     @Test
-    public void testHome() {
+    void testHome() {
         assertNotNull(smartsheet.homeResources());
     }
 
     @Test
-    public void testWorkspaces() {
+    void testWorkspaces() {
         assertNotNull(smartsheet.workspaceResources());
     }
 
     @Test
-    public void testFolders() {
+    void testFolders() {
         assertNotNull(smartsheet.folderResources());
     }
 
     @Test
-    public void testTemplates() {
+    void testTemplates() {
         assertNotNull(smartsheet.templateResources());
     }
 
     @Test
-    public void testSheets() {
+    void testSheets() {
         assertNotNull(smartsheet.sheetResources());
     }
 
     @Test
-    public void testfavorites() {
+    void testfavorites() {
         assertNotNull(smartsheet.favoriteResources());
     }
 
     @Test
-    public void testUsers() {
+    void testUsers() {
         assertNotNull(smartsheet.userResources());
     }
 
     @Test
-     public void testSearch() {
+    void testSearch() {
         assertNotNull(smartsheet.searchResources());
     }
 
     @Test
-    public void testReports() {
+    void testReports() {
         assertNotNull(smartsheet.reportResources());
     }
 
     @Test
-    public void testSetAssumedUser() { smartsheet.setAssumedUser("user"); }
+    void testSetAssumedUser() { smartsheet.setAssumedUser("user"); }
 
     @Test
-    public void testSetAccessToken() { smartsheet.setAccessToken("1234"); }
+    void testSetAccessToken() { smartsheet.setAccessToken("1234"); }
 
     @Test
-    public void testSights() { assertNotNull(smartsheet.sightResources()); }
+    void testSights() { assertNotNull(smartsheet.sightResources()); }
 }

--- a/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/TemplateResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/TemplateResourcesImplTest.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class TemplateResourcesImplTest extends ResourcesImplBase {
+class TemplateResourcesImplTest extends ResourcesImplBase {
 
     private TemplateResourcesImpl templateResources;
 
@@ -46,10 +46,7 @@ public class TemplateResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testTemplateResourcesImpl() {}
-
-    @Test
-    public void testListTemplates() throws IOException, SmartsheetException {
+    void testListTemplates() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/listTemplates.json"));
 
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);
@@ -63,7 +60,7 @@ public class TemplateResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testListPublicTemplates() throws IOException, SmartsheetException {
+    void testListPublicTemplates() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/listTemplates.json"));
 
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);

--- a/src/test/java/com/smartsheet/api/internal/UserResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/UserResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UserResourcesImplTest extends ResourcesImplBase {
+class UserResourcesImplTest extends ResourcesImplBase {
 
     private UserResourcesImpl userResources;
 
@@ -47,10 +47,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUserResourcesImpl() {}
-
-    @Test
-    public void testListUsers() throws SmartsheetException, IOException {
+    void testListUsers() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listUsers.json"));
         Set<String> email = new HashSet<String>();
         email.add("test@example.com");
@@ -60,7 +57,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
         pagination.setPage(1);
 
         PagedResult<User> userWrapper1 = userResources.listUsers();
-        assertTrue(userWrapper1.getData().size() == 2);
+        assertEquals(2, userWrapper1.getData().size());
 
         PagedResult<User> userWrapper = userResources.listUsers(email, pagination);
         assertTrue(userWrapper.getPageNumber() == 1);
@@ -79,7 +76,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAddUserUser() throws IOException, SmartsheetException {
+    void testAddUserUser() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/addUser.json"));
 
         User user = new User();
@@ -98,7 +95,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAddUserUserBoolean() throws IOException, SmartsheetException {
+    void testAddUserUserBoolean() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/addUser.json"));
 
         User user = new User();
@@ -117,7 +114,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetUser() throws SmartsheetException, IOException {
+    void testGetUser() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getUser.json"));
 
         UserProfile user = userResources.getUser(12345L);
@@ -130,7 +127,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetCurrentUser() throws SmartsheetException, IOException {
+    void testGetCurrentUser() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/getCurrentUser.json"));
 
         UserProfile user = userResources.getCurrentUser();
@@ -147,7 +144,7 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateUser() throws SmartsheetException, IOException {
+    void testUpdateUser() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/updateUser.json"));
 
         User user = new User();
@@ -163,14 +160,14 @@ public class UserResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteUser() throws IOException, SmartsheetException {
+    void testDeleteUser() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/deleteUser.json"));
         DeleteUserParameters parameters = new DeleteUserParameters(12345L, true, true);
         userResources.deleteUser(1234L, parameters);
     }
 
     @Test
-    public void testListOrgSheets() throws SmartsheetException, IOException {
+    void testListOrgSheets() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listOrgSheets.json"));
 
         PaginationParameters pagination = new PaginationParameters();

--- a/src/test/java/com/smartsheet/api/internal/UserResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/UserResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/WorkspaceFolderResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/WorkspaceFolderResourcesImplTest.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class WorkspaceFolderResourcesImplTest extends ResourcesImplBase {
+class WorkspaceFolderResourcesImplTest extends ResourcesImplBase {
 
     private WorkspaceFolderResourcesImpl workspaceFolderResources;
 
@@ -44,10 +44,7 @@ public class WorkspaceFolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testWorkspaceFolderResourcesImpl() {}
-
-    @Test
-    public void testListFolders() throws IOException, SmartsheetException {
+    void testListFolders() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/listWorkspaceFolders.json"));
 
         PaginationParameters parameters = new PaginationParameters(true,null,null);
@@ -62,7 +59,7 @@ public class WorkspaceFolderResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateFolder() throws IOException, SmartsheetException {
+    void testCreateFolder() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/newWorkspaceFolder.json"));
 
         Folder folder = new Folder.CreateFolderBuilder().setName("New Folder").build();

--- a/src/test/java/com/smartsheet/api/internal/WorkspaceResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/WorkspaceResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ import java.util.EnumSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class WorkspaceResourcesImplTest extends ResourcesImplBase {
+class WorkspaceResourcesImplTest extends ResourcesImplBase {
 
     private WorkspaceResourcesImpl workspaceResources;
 
@@ -47,10 +47,7 @@ public class WorkspaceResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testWorkspaceResourcesImpl() {}
-
-    @Test
-    public void testListWorkspaces() throws SmartsheetException, IOException {
+    void testListWorkspaces() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/listWorkspaces.json"));
         PaginationParameters parameters = new PaginationParameters(false, 1, 1);
         PagedResult<Workspace> workspace = workspaceResources.listWorkspaces(parameters);
@@ -67,7 +64,7 @@ public class WorkspaceResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testGetWorkspace() throws IOException, SmartsheetException {
+    void testGetWorkspace() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/getWorkspace.json"));
 
         Workspace workspace = workspaceResources.getWorkspace(1234L, true, EnumSet.allOf(SourceInclusion.class));
@@ -88,7 +85,7 @@ public class WorkspaceResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testCreateWorkspace() throws IOException, SmartsheetException {
+    void testCreateWorkspace() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/createWorkspace.json"));
 
         Workspace workspace = new Workspace();
@@ -101,7 +98,7 @@ public class WorkspaceResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testUpdateWorkspace() throws IOException, SmartsheetException {
+    void testUpdateWorkspace() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/updateWorkspace.json"));
 
         Workspace workspace = new Workspace();
@@ -114,18 +111,18 @@ public class WorkspaceResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testDeleteWorkspace() throws IOException, SmartsheetException {
+    void testDeleteWorkspace() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/deleteWorkspace.json"));
         workspaceResources.deleteWorkspace(1234L);
     }
 
     @Test
-    public void testCopyWorkspace() throws IOException, SmartsheetException {
+    void testCopyWorkspace() throws IOException, SmartsheetException {
         server.setResponseBody(new File("src/test/resources/copyWorkspace.json"));
         ContainerDestination containerDestination = new ContainerDestination();
         containerDestination.setDestinationType(DestinationType.WORKSPACE);
 
         Folder folder = workspaceResources.copyWorkspace(123L, containerDestination, null, null);
-        assertEquals(folder.getPermalink(), "https://{url}?lx=VL4YlIUnyYgASeX02grbLQ");
+        assertEquals("https://{url}?lx=VL4YlIUnyYgASeX02grbLQ", folder.getPermalink());
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/WorkspaceResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/WorkspaceResourcesImplTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/internal/http/DefaultHttpClientTest.java
+++ b/src/test/java/com/smartsheet/api/internal/http/DefaultHttpClientTest.java
@@ -31,22 +31,11 @@ import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class DefaultHttpClientTest {
-    HttpClient client;
-
-    @BeforeEach
-    public void setUp() throws Exception {
-        client = new DefaultHttpClient();
-    }
+class DefaultHttpClientTest {
+    private final HttpClient client = new DefaultHttpClient();
 
     @Test
-    public void testDefaultHttpClient() {}
-
-    @Test
-    public void testDefaultHttpClientCloseableHttpClient() { }
-
-    @Test
-    public void testRequest() throws HttpClientException, URISyntaxException {
+    void testRequest() throws HttpClientException, URISyntaxException {
         // Null Argument
         try {
             client.request(null);
@@ -66,7 +55,7 @@ public class DefaultHttpClientTest {
             // Expected
         }
 
-////        // Test each http method
+       // Test each http method
         request.setUri(new URI("http://google.com"));
         request.setMethod(HttpMethod.GET);
         client.request(request);

--- a/src/test/java/com/smartsheet/api/internal/json/JSONSerializerExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/JSONSerializerExceptionTest.java
@@ -26,13 +26,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class JSONSerializerExceptionTest {
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class JSONSerializerExceptionTest {
 
     @Test
-    public void testJSONSerializerExceptionString() {
+    void testJSONSerializerExceptionString() {
         Throwable throwable = assertThrows(JSONSerializerException.class, () -> {
             throw new JSONSerializerException("Test Exception");
         });
@@ -42,7 +39,7 @@ public class JSONSerializerExceptionTest {
 
 
     @Test
-    public void testJSONSerializerExceptionStringThrowable() throws JSONSerializerException {
+    void testJSONSerializerExceptionStringThrowable() throws JSONSerializerException {
         NullPointerException cause = new NullPointerException();
         Throwable throwable = assertThrows(JSONSerializerException.class, () -> {
             throw new JSONSerializerException("Test Exception1", cause);
@@ -54,7 +51,7 @@ public class JSONSerializerExceptionTest {
     }
 
     @Test
-    public void testJSONSerializerExceptionException() throws JSONSerializerException {
+    void testJSONSerializerExceptionException() throws JSONSerializerException {
         NullPointerException cause = new NullPointerException();
         Throwable throwable = assertThrows(JSONSerializerException.class, () -> {
             throw new JSONSerializerException(cause);

--- a/src/test/java/com/smartsheet/api/internal/json/JacksonJsonSerializerTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/JacksonJsonSerializerTest.java
@@ -26,31 +26,28 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.smartsheet.api.models.Folder;
 import com.smartsheet.api.models.Result;
 import com.smartsheet.api.models.User;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class JacksonJsonSerializerTest {
-    JacksonJsonSerializer jjs;
-
-    @BeforeEach
-    public void setUp() throws Exception {
-        jjs = new JacksonJsonSerializer();
-    }
+class JacksonJsonSerializerTest {
+    JacksonJsonSerializer jjs  = new JacksonJsonSerializer();
 
     @Test
-    public void testJacksonJsonSerializer() {}
-
-    @Test
-    public void testInit() {}
-
-    @Test
-    public void testSerialize() {
+    void testSerialize() {
         try{
             // Illegal Argument due to null
             try{
@@ -126,7 +123,7 @@ public class JacksonJsonSerializerTest {
     }
 
     @Test
-    public void testDeserialize() throws JSONSerializerException, JsonParseException, JsonMappingException, IOException {
+    void testDeserialize() throws JSONSerializerException, JsonParseException, JsonMappingException, IOException {
         try{
             // Illegal argument due to null
             try {
@@ -173,7 +170,7 @@ public class JacksonJsonSerializerTest {
     }
 
     @Test
-    public void testDeserializeMap() throws JSONSerializerException, FileNotFoundException, IOException {
+    void testDeserializeMap() throws JSONSerializerException, FileNotFoundException, IOException {
         // Test null pointer exceptions
         try {
             jjs.deserializeMap(null);
@@ -217,7 +214,7 @@ public class JacksonJsonSerializerTest {
     }
 
     @Test
-    public void testDeserializeList() throws JsonParseException, IOException, JSONSerializerException {
+    void testDeserializeList() throws JsonParseException, IOException, JSONSerializerException {
         // Test null pointer exceptions
         try {
             jjs.deserializeList(null, null);
@@ -287,7 +284,7 @@ public class JacksonJsonSerializerTest {
 
 
     @Test
-    public void testDeserializeResult() {
+    void testDeserializeResult() {
         try{
             try {
                 jjs.deserializeResult(null, null);
@@ -362,7 +359,7 @@ public class JacksonJsonSerializerTest {
     }
 
     @Test
-    public void testDeserializeListResult() {
+    void testDeserializeListResult() {
         try {
             try {
                 jjs.deserializeListResult(null, null);

--- a/src/test/java/com/smartsheet/api/internal/json/ObjectValueDeserializerTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/ObjectValueDeserializerTest.java
@@ -31,14 +31,15 @@ import java.util.Date;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ObjectValueDeserializerTest {
+class ObjectValueDeserializerTest {
     private static final double DELTA = 0.000001;
-    private JacksonJsonSerializer jacksonJsonSerializer = new JacksonJsonSerializer();
+    private final JacksonJsonSerializer jacksonJsonSerializer = new JacksonJsonSerializer();
 
     @Test
-    public void unknownObjectType() throws IOException, JSONSerializerException {
+    void unknownObjectType() throws IOException, JSONSerializerException {
         // If a new object type is introduced to the Smartsheet API, it shouldn't break existing integrations.
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"FUTURE_OBJECT_TYPE\"," +
@@ -47,11 +48,11 @@ public class ObjectValueDeserializerTest {
 
         ObjectValue objectValue = getObjectValue(json);
 
-        assertEquals(null, objectValue);
+        assertNull(objectValue);
     }
 
     @Test
-    public void unknownAttribute() throws IOException, JSONSerializerException {
+    void unknownAttribute() throws IOException, JSONSerializerException {
         // Verify that unknown attributes are ignored by the SDK
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DURATION\",\n" +
@@ -71,7 +72,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void duration_someAttributes() throws IOException, JSONSerializerException {
+    void duration_someAttributes() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DURATION\",\n" +
                 "                        \"days\": 1,\n" +
@@ -96,7 +97,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void duration_allAttributes() throws IOException, JSONSerializerException {
+    void duration_allAttributes() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DURATION\",\n" +
                 "                        \"negative\": true,\n" +
@@ -135,7 +136,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void duration_floatingPointValues() throws JSONSerializerException, IOException {
+    void duration_floatingPointValues() throws JSONSerializerException, IOException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DURATION\",\n" +
                 "                        \"negative\": true,\n" +
@@ -174,7 +175,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void abstractDateTime() throws IOException, JSONSerializerException {
+    void abstractDateTime() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"ABSTRACT_DATETIME\",\n" +
                 "                        \"value\": \"2017-07-01T16:30:07\"\n" +
@@ -193,7 +194,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void date() throws IOException, JSONSerializerException {
+    void date() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DATE\",\n" +
                 "                        \"value\": \"2017-07-17\"\n" +
@@ -212,7 +213,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void dateObjectValue_toDate() throws IOException, JSONSerializerException, ParseException {
+    void dateObjectValue_toDate() throws IOException, JSONSerializerException, ParseException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DATETIME\",\n" +
                 "                        \"value\": \"2017-07-17T20:27:57Z\"\n" +
@@ -234,7 +235,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void dateTime() throws IOException, JSONSerializerException, ParseException {
+    void dateTime() throws IOException, JSONSerializerException, ParseException {
         String json = "{\"objectValue\": {\n" +
                 "                        \"objectType\": \"DATETIME\",\n" +
                 "                        \"value\": \"2017-07-17T20:27:57Z\"\n" +
@@ -263,7 +264,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void longObjectValue() throws IOException, JSONSerializerException {
+    void longObjectValue() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\":123456}";
         ObjectValue actual = getObjectValue(json);
         PrimitiveObjectValue<Number> numberPrimitiveObjectValue = (PrimitiveObjectValue<Number>) actual;
@@ -273,7 +274,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void numberObjectValue() throws IOException, JSONSerializerException {
+    void numberObjectValue() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\":123456.789}";
         ObjectValue actual = getObjectValue(json);
         PrimitiveObjectValue<Number> numberPrimitiveObjectValue = (PrimitiveObjectValue<Number>) actual;
@@ -283,7 +284,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void stringObjectValue() throws IOException, JSONSerializerException {
+    void stringObjectValue() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\":\"foo\"}";
         ObjectValue actual = getObjectValue(json);
         PrimitiveObjectValue<String> primitiveObjectValue = (PrimitiveObjectValue<String>) actual;
@@ -293,7 +294,7 @@ public class ObjectValueDeserializerTest {
     }
 
     @Test
-    public void booleanObjectValue() throws IOException, JSONSerializerException {
+    void booleanObjectValue() throws IOException, JSONSerializerException {
         String json = "{\"objectValue\":true}";
         ObjectValue actual = getObjectValue(json);
         PrimitiveObjectValue<Boolean> primitiveObjectValue = (PrimitiveObjectValue<Boolean>) actual;

--- a/src/test/java/com/smartsheet/api/internal/oauth/OAuthFlowImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/oauth/OAuthFlowImplTest.java
@@ -43,7 +43,7 @@ import java.util.EnumSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class OAuthFlowImplTest {
+class OAuthFlowImplTest {
 
     OAuthFlowImpl oauth;
     String clientId = "clientID";
@@ -76,7 +76,7 @@ public class OAuthFlowImplTest {
     }
 
     @Test
-    public void testOAuthFlowImpl() {
+    void testOAuthFlowImpl() {
 
         assertEquals(clientId,oauth.getClientId());
         assertEquals(clientSecret, oauth.getClientSecret());
@@ -88,7 +88,7 @@ public class OAuthFlowImplTest {
     }
 
     @Test
-    public void testNewAuthorizationURL() throws UnsupportedEncodingException {
+    void testNewAuthorizationURL() throws UnsupportedEncodingException {
         try {
             oauth.newAuthorizationURL(null, null);
             fail("Should have thrown an exception.");
@@ -104,7 +104,7 @@ public class OAuthFlowImplTest {
     }
 
     @Test
-    public void testExtractAuthorizationResult() throws URISyntaxException, OAuthAuthorizationCodeException {
+    void testExtractAuthorizationResult() throws URISyntaxException, OAuthAuthorizationCodeException {
 
         try{
             oauth.extractAuthorizationResult(null);
@@ -167,7 +167,7 @@ public class OAuthFlowImplTest {
     }
 
     @Test
-    public void testObtainNewToken() throws NoSuchAlgorithmException, OAuthTokenException,
+    void testObtainNewToken() throws NoSuchAlgorithmException, OAuthTokenException,
         JSONSerializerException, HttpClientException, OAuthAuthorizationCodeException, URISyntaxException, InvalidRequestException, IOException {
         server.setStatus(403);
         server.setContentType("application/x-www-form-urlencoded");
@@ -188,7 +188,7 @@ public class OAuthFlowImplTest {
 
 
     @Test
-    public void testRefreshToken() throws InvalidRequestException, NoSuchAlgorithmException,
+    void testRefreshToken() throws InvalidRequestException, NoSuchAlgorithmException,
         UnsupportedEncodingException, OAuthTokenException, JSONSerializerException, HttpClientException,
         URISyntaxException {
         oauth.setTokenURL("https://api.smartsheet.com/1.1/token");
@@ -212,7 +212,7 @@ public class OAuthFlowImplTest {
     }
 
     @Test
-    public void testRevokeAccessToken() throws InvalidRequestException, NoSuchAlgorithmException,
+    void testRevokeAccessToken() throws InvalidRequestException, NoSuchAlgorithmException,
             UnsupportedEncodingException, OAuthTokenException, JSONSerializerException, HttpClientException,
             URISyntaxException {
         oauth.setTokenURL("https://api.smartsheet.com/1.1/token");

--- a/src/test/java/com/smartsheet/api/internal/util/DeleteUserParametersTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/DeleteUserParametersTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DeleteUserParametersTest {
+class DeleteUserParametersTest {
 
     @Test
-    public void testDeleteUserParametersModel() {
+    void testDeleteUserParametersModel() {
         DeleteUserParameters parameters = new DeleteUserParameters();
         parameters.setTransferToId(12345L);
         parameters.setTransferSheets(true);
@@ -45,7 +45,7 @@ public class DeleteUserParametersTest {
     }
 
     @Test
-    public void testToQueryString() {
+    void testToQueryString() {
         DeleteUserParameters parameters = new DeleteUserParameters(12345L, true, true);
         String[] matches1 = new String[] {"transferSheets=true", "removeFromSharing=true", "transferTo=12345"};
         for (String s : matches1)

--- a/src/test/java/com/smartsheet/api/internal/util/QueryUtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/QueryUtilTest.java
@@ -31,10 +31,10 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class QueryUtilTest {
+class QueryUtilTest {
 
     @Test
-    public void testGenerateCommaSeparatedList() {
+    void testGenerateCommaSeparatedList() {
         Set<Long> list = new HashSet<Long>();
         list.add(123456789L);
         list.add(987654321L);
@@ -51,7 +51,7 @@ public class QueryUtilTest {
     }
 
     @Test
-    public void testGenerateUrl() {
+    void testGenerateUrl() {
         assertEquals("", QueryUtil.generateUrl(null, null));
         assertEquals("url", QueryUtil.generateUrl("url", null));
 

--- a/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
@@ -31,9 +31,9 @@ import java.io.InputStream;
 /**
  *
  */
-public class StreamUtilTest {
+class StreamUtilTest {
     @Test
-    public void testReadBytesFromStream() throws Exception {
+    void testReadBytesFromStream() throws Exception {
         final String testString = "fuzzy wuzzy was a bear; fuzzy wuzzy had no hair...";
         final byte[] testBytes = testString.getBytes("UTF-8");
         final InputStream inputStream = new CharSequenceInputStream(testString, "UTF-8");

--- a/src/test/java/com/smartsheet/api/internal/util/UtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/UtilTest.java
@@ -1,0 +1,208 @@
+package com.smartsheet.api.internal.util;
+
+/*
+ * #[license]
+ * Smartsheet Java SDK
+ * %%
+ * Copyright (C) 2014 - 2016 Smartsheet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * %[license]
+ */
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UtilTest {
+    @Nested
+    class ThrowIfNullTests {
+
+        @Nested
+        class ThrowIfNullOneArgTests {
+            @Test
+            void throwIfNullOneArg_null() {
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull((Object) null))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfNullOneArg_nonnull() {
+                //Arrange
+                Object obj = new Object();
+
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfNull(obj));
+            }
+        }
+
+        @Nested
+        class ThrowIfNullTwoArgsTests {
+            @Test
+            void throwIfNullTwoArgs_null_null() {
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull(null, null))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfNullTwoArgs_nonnull_null() {
+                //Arrange
+                Object obj = new Object();
+
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull(obj, null))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfNullTwoArgs_null_nonnull() {
+                //Arrange
+                Object obj = new Object();
+
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull(null, obj))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfNullTwoArgs_nonnull_nonnull() {
+                //Arrange
+                Object obj1 = new Object();
+                Object obj2 = new Object();
+
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfNull(obj1, obj2));
+            }
+        }
+
+        @Nested
+        class ThrowIfNullVarArgsTests {
+            @Test
+            void throwIfNullVarArgs_null_null_null() {
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull(null, null, null))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfNullVarArgs_null_null_nonnull() {
+                //Arrange
+                Object obj = new Object();
+
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull( null, null, obj))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfNullVarArgs_nonnull_nonnull_nonnull() {
+                //Arrange
+                Object obj1 = new Object();
+                Object obj2 = new Object();
+                Object obj3 = new Object();
+
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfNull(obj1, obj2, obj3));
+            }
+
+            @Test
+            void throwIfNullVarArgs_nonnullArray() {
+                //Arrange
+                Object[] objArray = new Object[] {
+                        new Object(),
+                        new Object(),
+                        new Object()
+                };
+
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfNull(objArray));
+            }
+
+            @Test
+            void throwIfNullVarArgs_nullArray() {
+                //Arrange
+                Object[] objArray = new Object[] {
+                        new Object(),
+                        new Object(),
+                        null
+                };
+
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfNull(objArray))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+    }
+
+
+    @Nested
+    class ThrowIfEmptyTests {
+        @Nested
+        class ThrowIfEmptyOneArgTests {
+            @Test
+            void throwIfEmptyOneArg_notEmpty() {
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfEmpty("Not Empty"));
+            }
+            @Test
+            void throwIfEmptyOneArg_null() {
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfEmpty((String) null));
+            }
+
+            @Test
+            void throwIfEmptyOneArg_empty() {
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfEmpty(""))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+        @Nested
+        class ThrowIfEmptyVarArgsTests {
+
+            @Test
+            void throwIfEmptyVarArgs_notEmpty_notEmpty() {
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfEmpty("Not Empty", "Also Not"));
+            }
+            @Test
+            void throwIfEmptyVarArgs_null_null() {
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfEmpty(null, null));
+            }
+            @Test
+            void throwIfEmptyVarArgs_notEmpty_null() {
+                // Act & Assert
+                assertThatNoException().isThrownBy(() -> Util.throwIfEmpty("Not Empty", null));
+            }
+
+            @Test
+            void throwIfEmptyVarArgs_empty_empty() {
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfEmpty("", ""))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+
+            @Test
+            void throwIfEmptyVarArgs_notEmpty_empty() {
+                // Act & Assert
+                assertThatThrownBy(() -> Util.throwIfEmpty("Not Empty", ""))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/com/smartsheet/api/logging/LoggingTest.java
+++ b/src/test/java/com/smartsheet/api/logging/LoggingTest.java
@@ -37,7 +37,7 @@ import java.io.ByteArrayOutputStream;
 /**
  *
  */
-public class LoggingTest {
+class LoggingTest {
     @BeforeAll
     public static void dontFailOnUnrecongnizedFields() {
         // Setup the serializer
@@ -71,7 +71,7 @@ public class LoggingTest {
     }
 
     @Test
-    public void testCustomLogging() throws Exception {
+    void testCustomLogging() throws Exception {
         ByteArrayOutputStream traceStream = new ByteArrayOutputStream();
         DefaultHttpClient.setTraceStream(traceStream);
         Smartsheet client = new SmartsheetBuilder().setAccessToken("ll352u9jujauoqz4gstvsae05").build(); // using "null" as token results in NPE

--- a/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
+++ b/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class AccessLevelTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class AccessLevelTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(AccessLevel.valueOf("VIEWER"));
         assertNotNull(AccessLevel.valueOf("EDITOR"));
         assertNotNull(AccessLevel.valueOf("EDITOR_SHARE"));

--- a/src/test/java/com/smartsheet/api/models/AccessScopeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AccessScopeTest.java
@@ -28,10 +28,10 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AccessScopeTest {
+class AccessScopeTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(AccessScope.valueOf("ADMIN_SHEETS"));
         assertNotNull(AccessScope.valueOf("ADMIN_SIGHTS"));
         assertNotNull(AccessScope.valueOf("ADMIN_USERS"));
@@ -52,7 +52,7 @@ public class AccessScopeTest {
     }
 
     @Test
-    public void bothVersionsOfAccessScopeAreIdentical() {
+    void bothVersionsOfAccessScopeAreIdentical() {
         Set<String> scopeNames = new HashSet<String>();
         for (AccessScope accessScope : AccessScope.values()) {
             scopeNames.add(accessScope.name());

--- a/src/test/java/com/smartsheet/api/models/AttachmentParentTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AttachmentParentTypeTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class AttachmentParentTypeTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class AttachmentParentTypeTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(AttachmentParentType.valueOf("SHEET"));
         assertNotNull(AttachmentParentType.valueOf("ROW"));
         assertNotNull(AttachmentParentType.valueOf("COMMENT"));

--- a/src/test/java/com/smartsheet/api/models/AttachmentSubTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AttachmentSubTypeTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class AttachmentSubTypeTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class AttachmentSubTypeTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(AttachmentSubType.valueOf("DOCUMENT"));
         assertNotNull(AttachmentSubType.valueOf("SPREADSHEET"));
         assertNotNull(AttachmentSubType.valueOf("PRESENTATION"));

--- a/src/test/java/com/smartsheet/api/models/AttachmentTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/AttachmentTypeTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class AttachmentTypeTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class AttachmentTypeTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(AttachmentType.valueOf("FILE"));
         assertNotNull(AttachmentType.valueOf("GOOGLE_DRIVE"));
         assertNotNull(AttachmentType.valueOf("LINK"));

--- a/src/test/java/com/smartsheet/api/models/ColumnTagTest.java
+++ b/src/test/java/com/smartsheet/api/models/ColumnTagTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ColumnTagTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class ColumnTagTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(ColumnTag.valueOf("CALENDAR_START_DATE"));
         assertNotNull(ColumnTag.valueOf("CALENDAR_END_DATE"));
         assertNotNull(ColumnTag.valueOf("GANTT_START_DATE"));

--- a/src/test/java/com/smartsheet/api/models/ColumnTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/ColumnTypeTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ColumnTypeTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class ColumnTypeTest {
 
     @Test
-    public void test() {
+    void test() {
 
         assertNotNull(ColumnType.valueOf("TEXT_NUMBER"));
         assertNotNull(ColumnType.valueOf("PICKLIST"));

--- a/src/test/java/com/smartsheet/api/models/IdentifiableModelTest.java
+++ b/src/test/java/com/smartsheet/api/models/IdentifiableModelTest.java
@@ -25,14 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class IdentifiableModelTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class IdentifiableModelTest {
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         Row row = new Row();
         // Same Object
         assertEquals(row,row);
@@ -48,7 +44,7 @@ public class IdentifiableModelTest {
     }
 
     @Test
-    public void testEqualsObject() {
+    void testEqualsObject() {
         Row row = new Row();
         assertNotNull(row.hashCode());
     }

--- a/src/test/java/com/smartsheet/api/models/ObjectExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/ObjectExclusionTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ObjectExclusionTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class ObjectExclusionTest {
 
     @Test
-    public void testObjectInclusion() {
+    void testObjectInclusion() {
         assertNotNull(ObjectExclusion.valueOf("NONEXISTENT_CELLS"));
 
         assertEquals(1,ObjectExclusion.values().length);

--- a/src/test/java/com/smartsheet/api/models/ObjectInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/ObjectInclusionTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ObjectInclusionTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class ObjectInclusionTest {
 
     @Test
-    public void testObjectInclusion() {
+    void testObjectInclusion() {
         assertNotNull(ObjectInclusion.valueOf("DISCUSSIONS"));
         assertNotNull(ObjectInclusion.valueOf("ATTACHMENTS"));
         assertNotNull(ObjectInclusion.valueOf("DATA"));

--- a/src/test/java/com/smartsheet/api/models/PaginationParametersTest.java
+++ b/src/test/java/com/smartsheet/api/models/PaginationParametersTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.models;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/models/PaginationParametersTest.java
+++ b/src/test/java/com/smartsheet/api/models/PaginationParametersTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.models;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,10 +26,10 @@ import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PaginationParametersTest {
+class PaginationParametersTest {
 
     @Test
-    public void testPaginationParameters() {
+    void testPaginationParameters() {
         PaginationParameters parameters = new PaginationParameters(true, 1, 1);
 
         assertTrue(parameters.isIncludeAll());
@@ -38,7 +38,7 @@ public class PaginationParametersTest {
     }
 
     @Test
-    public void testToQueryString() {
+    void testToQueryString() {
         PaginationParameters parameters1 = new PaginationParameters(true, null, null);
         assertEquals("?includeAll=true", parameters1.toQueryString());
 
@@ -53,7 +53,8 @@ public class PaginationParametersTest {
         }
     }
 
-    @Test public void testToHashMap() {
+    @Test
+    void testToHashMap() {
         PaginationParameters parameters1 = new PaginationParameters(true, null, null);
         HashMap<String, Object> map = parameters1.toHashMap();
         assertTrue(map.containsKey("includeAll"));
@@ -79,7 +80,7 @@ public class PaginationParametersTest {
     }
 
     @Test
-    public void testBuilder() {
+    void testBuilder() {
         PaginationParameters pagination = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).setPageSize(2).setPage(1).build();
         assertTrue(pagination.isIncludeAll());
         assertEquals(2, pagination.getPageSize().longValue());

--- a/src/test/java/com/smartsheet/api/models/PaperSizeTest.java
+++ b/src/test/java/com/smartsheet/api/models/PaperSizeTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class PaperSizeTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class PaperSizeTest {
 
     @Test
-    public void test() {
+    void test() {
 
         assertNotNull(PaperSize.valueOf("LETTER"));
         assertNotNull(PaperSize.valueOf("LEGAL"));

--- a/src/test/java/com/smartsheet/api/models/RecipientEmailTest.java
+++ b/src/test/java/com/smartsheet/api/models/RecipientEmailTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class RecipientEmailTest {
+class RecipientEmailTest {
 
     @Test
-    public void testRecipientEmail() {
+    void testRecipientEmail() {
         RecipientEmail recipient = new RecipientEmail();
         recipient.setEmail("johndoe@smartsheet.com");
 

--- a/src/test/java/com/smartsheet/api/models/RecipientGroupTest.java
+++ b/src/test/java/com/smartsheet/api/models/RecipientGroupTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class RecipientGroupTest {
+class RecipientGroupTest {
 
     @Test
-    public void testRecipientGroup() {
+    void testRecipientGroup() {
         RecipientGroup recipient = new RecipientGroup();
         recipient.setGroupId(123456789L);
 

--- a/src/test/java/com/smartsheet/api/models/RowTest.java
+++ b/src/test/java/com/smartsheet/api/models/RowTest.java
@@ -29,14 +29,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RowTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class RowTest {
 
     @Test
-    public void testGetColumnByIndex() {
+    void testGetColumnByIndex() {
         Row row = new Row();
         Column col = new Column();
         col.setId(1234L);
@@ -61,7 +57,7 @@ public class RowTest {
     }
 
     @Test
-    public void testInsertRowBuilder() {
+    void testInsertRowBuilder() {
         Format format = new Format("new format");
         List<Cell> cells = new ArrayList<Cell>();
         Row row = new Row.AddRowBuilder().setToTop(true).setExpanded(false).setFormat(format).setCells(cells).build();
@@ -77,7 +73,7 @@ public class RowTest {
     }
 
     @Test
-    public void testUpdateRowBuilder() {
+    void testUpdateRowBuilder() {
         Format format = new Format("new format");
         List<Cell> cells = new ArrayList<Cell>();
         Row row = new Row.UpdateRowBuilder().setToTop(true).setExpanded(false).setFormat(format).setCells(cells).setLocked(true).build();

--- a/src/test/java/com/smartsheet/api/models/SheetEmailFormatTest.java
+++ b/src/test/java/com/smartsheet/api/models/SheetEmailFormatTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class SheetEmailFormatTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class SheetEmailFormatTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(SheetEmailFormat.valueOf("PDF"));
         assertNotNull(SheetEmailFormat.valueOf("EXCEL"));
         assertEquals(3,SheetEmailFormat.values().length);

--- a/src/test/java/com/smartsheet/api/models/SheetTest.java
+++ b/src/test/java/com/smartsheet/api/models/SheetTest.java
@@ -29,14 +29,10 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class SheetTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class SheetTest {
 
     @Test
-    public void testGetRowByRowNumber() {
+    void testGetRowByRowNumber() {
         Sheet sheet = new Sheet();
         sheet.setReadOnly(false);
         sheet.setDiscussions(new ArrayList<Discussion>());

--- a/src/test/java/com/smartsheet/api/models/SymbolTest.java
+++ b/src/test/java/com/smartsheet/api/models/SymbolTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class SymbolTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class SymbolTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(Symbol.valueOf("FLAG"));
         assertNotNull(Symbol.valueOf("STAR"));
         assertNotNull(Symbol.valueOf("HARVEY_BALLS"));

--- a/src/test/java/com/smartsheet/api/models/SystemColumnTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/SystemColumnTypeTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class SystemColumnTypeTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class SystemColumnTypeTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(SystemColumnType.valueOf("AUTO_NUMBER"));
         assertNotNull(SystemColumnType.valueOf("MODIFIED_DATE"));
         assertNotNull(SystemColumnType.valueOf("MODIFIED_BY"));

--- a/src/test/java/com/smartsheet/api/models/UserStatusTest.java
+++ b/src/test/java/com/smartsheet/api/models/UserStatusTest.java
@@ -27,14 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class UserStatusTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class UserStatusTest {
 
     @Test
-    public void test() {
+    void test() {
         assertNotNull(UserStatus.valueOf("ACTIVE"));
         assertNotNull(UserStatus.valueOf("PENDING"));
         assertNotNull(UserStatus.valueOf("DECLINED"));

--- a/src/test/java/com/smartsheet/api/models/format/FormatTest.java
+++ b/src/test/java/com/smartsheet/api/models/format/FormatTest.java
@@ -35,17 +35,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
-public class FormatTest {
+class FormatTest {
 
     @Mock
-    JsonGenerator generator;
+    private JsonGenerator generator;
     @Mock
-    SerializerProvider provider;
-
-    @BeforeEach
-    public void setup() {
-
-    }
+    private SerializerProvider provider;
     private final static int U = Format.UNSET;
     enum ParserTests {
         VALID_A     (",,1,1,1,,,,20,29,,,,,,",      new int[]{U,U,1,1,1,U,U,U,20,29,U,U,U,U,U,U}),
@@ -67,7 +62,7 @@ public class FormatTest {
     }
 
     @Test
-    public void testParser() {
+    void testParser() {
         for (ParserTests t : ParserTests.values()) {
             Format f = new Format(t.format);
             int i = 0;
@@ -79,7 +74,7 @@ public class FormatTest {
     }
 
     @Test
-    public void testFormatBuilderAllDefaults() throws IOException {
+    void testFormatBuilderAllDefaults() throws IOException {
         Format actual = new Format.FormatBuilder()
                 .build();
 
@@ -87,7 +82,7 @@ public class FormatTest {
     }
 
     @Test
-    public void testFormatBuilderVariousSettings() throws IOException {
+    void testFormatBuilderVariousSettings() throws IOException {
         Format actual = new Format.FormatBuilder()
                 .withBackgroundColor(Color.ORANGE_4)
                 .withCurrency(Currency.BRAZIL_REAIS)
@@ -100,7 +95,7 @@ public class FormatTest {
     }
 
     @Test
-    public void testAllFormats() throws IOException {
+    void testAllFormats() throws IOException {
         runTestCases(FontFamilyTest.values());
         runTestCases(FontSizeTest.values());
         runTestCases(BoldTest.values());

--- a/src/test/java/com/smartsheet/api/oauth/OAuthTokenExceptionTest.java
+++ b/src/test/java/com/smartsheet/api/oauth/OAuthTokenExceptionTest.java
@@ -25,14 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class OAuthTokenExceptionTest {
-
-    @BeforeEach
-    public void setUp() throws Exception {
-    }
+class OAuthTokenExceptionTest {
 
     @Test
-    public void testOAuthTokenExceptionString() {
+    void testOAuthTokenExceptionString() {
         try{
             throw new OAuthTokenException("message");
         }catch(OAuthTokenException e){
@@ -41,7 +37,7 @@ public class OAuthTokenExceptionTest {
     }
 
     @Test
-    public void testOAuthTokenExceptionStringThrowable() {
+    void testOAuthTokenExceptionStringThrowable() {
         try{
             throw new OAuthTokenException("message", null);
         }catch(OAuthTokenException ex){

--- a/src/test/java/com/smartsheet/api/sdk_test/AutomationRulesTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/AutomationRulesTest.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AutomationRulesTest {
+class AutomationRulesTest {
 
     @Test
-    public void ListAutomationRules() {
+    void ListAutomationRules() {
         try {
             Smartsheet ss = HelperFunctions.SetupClient("List Automation Rules");
             PagedResult<AutomationRule> automationRules = ss.sheetResources().automationRuleResources().listAutomationRules(324, null);
@@ -45,7 +45,7 @@ public class AutomationRulesTest {
     }
 
     @Test
-    public void GetAutomationRule() {
+    void GetAutomationRule() {
         Smartsheet ss = HelperFunctions.SetupClient("Get Automation Rule");
         try {
             AutomationRule automationRule = ss.sheetResources().automationRuleResources().getAutomationRule(324, 284);
@@ -58,7 +58,7 @@ public class AutomationRulesTest {
 
     @Disabled("awaiting API update to return Result object")
     @Test
-    public void UpdateAutomationRule() {
+    void UpdateAutomationRule() {
         Smartsheet ss = HelperFunctions.SetupClient("Update Automation Rule");
         AutomationAction autoRuleAction = new AutomationAction();
         RecipientEmail recipient = new RecipientEmail();
@@ -79,7 +79,7 @@ public class AutomationRulesTest {
     }
 
     @Test
-    public void DeleteAutomationRule() {
+    void DeleteAutomationRule() {
         Smartsheet ss = HelperFunctions.SetupClient("Delete Automation Rule");
         try {
             ss.sheetResources().automationRuleResources().deleteAutomationRule(324, 284);

--- a/src/test/java/com/smartsheet/api/sdk_test/HelperFunctions.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/HelperFunctions.java
@@ -25,7 +25,7 @@ import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetBuilder;
 import org.junit.jupiter.api.Assertions;
 
-public class HelperFunctions {
+class HelperFunctions {
 	public static Smartsheet SetupClient(String apiScenario){
 		TestHttpClient testHttpClient = new TestHttpClient(apiScenario);
 		Smartsheet ss = new SmartsheetBuilder()

--- a/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
@@ -8,9 +8,9 @@ package com.smartsheet.api.sdk_test;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
@@ -8,9 +8,9 @@ package com.smartsheet.api.sdk_test;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,11 +29,11 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-public class RowTest {
+class RowTest {
 
 
 	@Test
-	public void ListSheets_NoParams()
+	void ListSheets_NoParams()
 	{
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
@@ -45,7 +45,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignValues_String()
+	void addRows_AssignValues_String()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - String");
@@ -79,7 +79,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_Location_Top()
+	void addRows_Location_Top()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Location - Top");
@@ -107,7 +107,7 @@ public class RowTest {
 	}
 
   	@Test
-	public void addRows_Location_Bottom()
+	void addRows_Location_Bottom()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Location - Bottom");
@@ -134,7 +134,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignValues_Int()
+	void addRows_AssignValues_Int()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Int");
@@ -170,7 +170,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignValues_Bool()
+	void addRows_AssignValues_Bool()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Bool");
@@ -206,7 +206,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignFormulae()
+	void addRows_AssignFormulae()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Formulae");
@@ -232,7 +232,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignValues_Hyperlink()
+	void addRows_AssignValues_Hyperlink()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink");
@@ -265,7 +265,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignValues_HyperlinkSheetID()
+	void addRows_AssignValues_HyperlinkSheetID()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink SheetID");
@@ -298,7 +298,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_AssignValues_HyperlinkReportID()
+	void addRows_AssignValues_HyperlinkReportID()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink ReportID");
@@ -331,7 +331,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_Invalid_AssignHyperlinkUrlandSheetId()
+	void addRows_Invalid_AssignHyperlinkUrlandSheetId()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Hyperlink URL and SheetId");
@@ -363,7 +363,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void addRows_Invalid_AssignValueAndFormulae()
+	void addRows_Invalid_AssignValueAndFormulae()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Value and Formulae");
@@ -389,7 +389,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void AddRows_AssignObjectValue_PredecessorList()
+	void AddRows_AssignObjectValue_PredecessorList()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Object Value - Predecessor List (using floats)");
@@ -419,7 +419,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignValues_String()
+	void UpdateRows_AssignValues_String()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - String");
@@ -456,7 +456,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignValues_Int()
+	void UpdateRows_AssignValues_Int()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Int");
@@ -493,7 +493,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignValues_Bool()
+	void UpdateRows_AssignValues_Bool()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Bool");
@@ -530,7 +530,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignFormulae()
+	void UpdateRows_AssignFormulae()
 	{
 		try{
 			Smartsheet ss =  HelperFunctions.SetupClient("Update Rows - Assign Formulae");
@@ -557,7 +557,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignValues_Hyperlink()
+	void UpdateRows_AssignValues_Hyperlink()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink");
@@ -591,7 +591,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignValues_HyperlinkSheetID()
+	void UpdateRows_AssignValues_HyperlinkSheetID()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink SheetID");
@@ -625,7 +625,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_AssignValues_HyperlinkReportID()
+	void UpdateRows_AssignValues_HyperlinkReportID()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink ReportID");
@@ -659,7 +659,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_Invalid_AssignHyperlinkUrlandSheetId()
+	void UpdateRows_Invalid_AssignHyperlinkUrlandSheetId()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink URL and SheetId");
@@ -692,7 +692,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_Invalid_AssignValueAndFormulae()
+	void UpdateRows_Invalid_AssignValueAndFormulae()
 	{
 		try{
 			Smartsheet ss =  HelperFunctions.SetupClient("Update Rows - Invalid - Assign Value and Formulae");
@@ -719,7 +719,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_ClearValue_TextNumber()
+	void UpdateRows_ClearValue_TextNumber()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Text Number");
@@ -742,7 +742,7 @@ public class RowTest {
 	}
 
     @Test
-	public void UpdateRows_ClearValue_Checkbox()
+	void UpdateRows_ClearValue_Checkbox()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Checkbox");
@@ -765,7 +765,7 @@ public class RowTest {
 	}
 
     @Test
-	public void UpdateRows_ClearValue_Hyperlink()
+	void UpdateRows_ClearValue_Hyperlink()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Hyperlink");
@@ -790,7 +790,7 @@ public class RowTest {
 	}
 
     @Test
-	public void UpdateRows_ClearValue_CellLink()
+	void UpdateRows_ClearValue_CellLink()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Cell Link");
@@ -815,7 +815,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void UpdateRows_Invalid_AssignHyperlinkAndCellLink()
+	void UpdateRows_Invalid_AssignHyperlinkAndCellLink()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink and Cell Link");
@@ -845,7 +845,7 @@ public class RowTest {
 	}
 
     @Test
-	public void UpdateRows_Location_Top()
+	void UpdateRows_Location_Top()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Location - Top");
@@ -865,7 +865,7 @@ public class RowTest {
 	}
 
     @Test
-	public void UpdateRows_Location_Bottom()
+	void UpdateRows_Location_Bottom()
 	{
 		try{
 			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Location - Bottom");

--- a/src/test/java/com/smartsheet/api/sdk_test/SheetTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/SheetTest.java
@@ -8,9 +8,9 @@ package com.smartsheet.api.sdk_test;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,11 +32,11 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 
 
-public class SheetTest {
+class SheetTest {
 
-	
+
 	@Test
-	public void ListSheets_NoParams()
+	void ListSheets_NoParams()
 	{
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
@@ -48,7 +48,7 @@ public class SheetTest {
 	}
 
 	@Test
-	public void ListSheets_IncludeOwnerInfo()
+	void ListSheets_IncludeOwnerInfo()
 	{
 		try{
 			Smartsheet ss =  HelperFunctions.SetupClient("List Sheets - Include Owner Info");
@@ -60,7 +60,7 @@ public class SheetTest {
 	}
 
 	@Test
-	public void CreateSheet__Invalid_NoColumns()
+	void CreateSheet__Invalid_NoColumns()
 	{
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("Create Sheet - Invalid - No Columns");

--- a/src/test/java/com/smartsheet/api/sdk_test/SightsTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/SightsTest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.sdk_test;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
 
-public class SightsTest {
+class SightsTest {
 
     @Test
-    public void ListSights() {
+    void ListSights() {
         try {
             Smartsheet ss = HelperFunctions.SetupClient("List Sights");
             PagedResult<Sight> sights = ss.sightResources().listSights(null, null);
@@ -42,7 +42,7 @@ public class SightsTest {
     }
 
     @Test
-    public void GetSight() {
+    void GetSight() {
         Smartsheet ss = HelperFunctions.SetupClient("Get Sight");
         try {
             Sight sight = ss.sightResources().getSight(52);
@@ -55,7 +55,7 @@ public class SightsTest {
 
     @Disabled("destination types differ because of case")
     @Test
-    public void CopySight() {
+    void CopySight() {
         Smartsheet ss = HelperFunctions.SetupClient("Copy Sight");
         try {
             ContainerDestination dest = new ContainerDestination();
@@ -70,7 +70,7 @@ public class SightsTest {
     }
 
     @Test
-    public void UpdateSight() {
+    void UpdateSight() {
         Smartsheet ss = HelperFunctions.SetupClient("Update Sight");
         try {
             Sight sight = new Sight();
@@ -84,7 +84,7 @@ public class SightsTest {
     }
 
     @Test
-    public void SetPublishStatus() {
+    void SetPublishStatus() {
         Smartsheet ss = HelperFunctions.SetupClient("Set Sight Publish Status");
         try {
             SightPublish publish = new SightPublish();
@@ -98,11 +98,11 @@ public class SightsTest {
     }
 
     @Test
-    public void GetPublishStatus() {
+    void GetPublishStatus() {
         Smartsheet ss = HelperFunctions.SetupClient("Get Sight Publish Status");
         try {
             SightPublish publish = ss.sightResources().getPublishStatus(812L);
-           Assertions.assertEquals(publish.getReadOnlyFullEnabled(), true);
+           Assertions.assertTrue(publish.getReadOnlyFullEnabled());
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -110,7 +110,7 @@ public class SightsTest {
     }
 
     @Test
-    public void DeleteSight() {
+    void DeleteSight() {
         Smartsheet ss = HelperFunctions.SetupClient("Delete Sight");
         try {
             ss.sightResources().deleteSight(700L);

--- a/src/test/java/com/smartsheet/api/sdk_test/TestHttpClient.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/TestHttpClient.java
@@ -25,7 +25,7 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.internal.http.HttpRequest;
 import org.apache.http.client.methods.HttpRequestBase;
 
-public class TestHttpClient extends DefaultHttpClient {
+class TestHttpClient extends DefaultHttpClient {
 
     private String apiScenario;
 


### PR DESCRIPTION
- Remove unnecessary `public` modifiers from tests
- Remove empty tests (they provide no value)
- Fix some assertions to be in the correct order of actual vs expected
- Make some vars private or final where appropriate
- Add AssertJ assertions library because they are easier to read and harder to mess up the order of actual vs expected
- Added `UtilTest` as an example of how I would propose writing tests in the future
  - Utilizes `@Nested` to separate tests by method so that methods and tests can easily be moved around and it's easy to find the tests correlated with a method
  - Uses AssertJ instead of Junit Assertions because I believe `assertThat(<expected>).isXXX` reads better than `assertEquals` and `assertTrue`