### PR TITLE
Update Test Junit import style

### DIFF
--- a/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
@@ -22,11 +22,12 @@ package com.smartsheet.api.internal.util;
 
 
 import org.apache.commons.io.input.CharSequenceInputStream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  *
@@ -46,13 +47,13 @@ public class StreamUtilTest {
             System.out.println("same stream returned (reset)");
             // verify readBytesFromStream gets everything from the inputStream (it also verifies cloneContent resets the source)
             byte[] streamBytes = StreamUtil.readBytesFromStream(inputStream);
-            Assertions.assertArrayEquals(testBytes, streamBytes); // it's all US-ASCII so it should match UTF-8 bytes
+           assertArrayEquals(testBytes, streamBytes); // it's all US-ASCII so it should match UTF-8 bytes
         } else {
             System.out.println("new stream returned");
             byte[] backupBytes = StreamUtil.readBytesFromStream(backupStream);
-           Assertions.assertArrayEquals(testBytes, backupBytes);
+          assertArrayEquals(testBytes, backupBytes);
         }
 
-       Assertions.assertArrayEquals(testBytes, copyStream.toByteArray());
+      assertArrayEquals(testBytes, copyStream.toByteArray());
     }
 }

--- a/src/test/java/com/smartsheet/api/logging/LoggingTest.java
+++ b/src/test/java/com/smartsheet/api/logging/LoggingTest.java
@@ -28,11 +28,13 @@ import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.internal.json.JacksonJsonSerializer;
 import com.smartsheet.api.models.Sheet;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -57,16 +59,16 @@ public class LoggingTest {
         client.setTraces(Trace.Request, Trace.Response);    // should log entire request and response
         try {
             Sheet sheet = client.sheetResources().getSheet(42, null, null, null, null, null, 1, 1);
-           Assertions.fail("expected SmartsheetException");
+          fail("expected SmartsheetException");
         } catch (SmartsheetException expected) {
             String output = traceStream.toString();
             // not super-robust but asserts some of the important parts
-           Assertions.assertTrue(output.contains("\"request\" : {"), "request not found in - " + output);
-           Assertions.assertTrue(output.contains("\"Authorization\" : \"Bearer ****null"), "Auth header not found in - " + output); // truncated Auth header
-           Assertions.assertTrue(output.contains("\"response\" : {"), "response not found in - " + output);
-           Assertions.assertTrue(output.contains("\"body\" : \"{\\n  \\\"errorCode\\\" : 1002,\\n  \\\"message\\\" : " +
+          assertTrue(output.contains("\"request\" : {"), "request not found in - " + output);
+          assertTrue(output.contains("\"Authorization\" : \"Bearer ****null"), "Auth header not found in - " + output); // truncated Auth header
+          assertTrue(output.contains("\"response\" : {"), "response not found in - " + output);
+          assertTrue(output.contains("\"body\" : \"{\\n  \\\"errorCode\\\" : 1002,\\n  \\\"message\\\" : " +
                             "\\\"Your Access Token is invalid.\\\",\\n  \\\"refId\\\" :"), "response-body not found in - " + output);
-           Assertions.assertTrue(output.contains("\"status\" : \"HTTP/1.1 401 Unauthorized\""), "status not found in - " + output);
+          assertTrue(output.contains("\"status\" : \"HTTP/1.1 401 Unauthorized\""), "status not found in - " + output);
         }
     }
 
@@ -78,15 +80,15 @@ public class LoggingTest {
         client.setTraces(Trace.Request, Trace.Response);    // should log entire request and response
         try {
             Sheet sheet = client.sheetResources().getSheet(42, null, null, null, null, null, 1, 1);
-           Assertions.fail("expected SmartsheetException");
+          fail("expected SmartsheetException");
         } catch (SmartsheetException expected) {
             String output = traceStream.toString();
             // not super-robust but asserts some of the important parts
-           Assertions.assertTrue(output.contains("request:{"), "request not found in - " + output);
-           Assertions.assertTrue(output.contains("'Authorization':'Bearer ****ae05"), "Auth header not found in - " + output); // truncated Auth header
-           Assertions.assertTrue(output.contains("response:{"), "response not found in - " + output);
-           Assertions.assertTrue(output.contains("body:'{\n  \"errorCode\" : 1002,\n  \"message\" : \"Your Access Token is invalid.\",\n  \"refId\" :"), "response-body not found in - " + output);
-           Assertions.assertTrue(output.contains("status:'HTTP/1.1 401 Unauthorized'"), "status not found in - " + output);
+          assertTrue(output.contains("request:{"), "request not found in - " + output);
+          assertTrue(output.contains("'Authorization':'Bearer ****ae05"), "Auth header not found in - " + output); // truncated Auth header
+          assertTrue(output.contains("response:{"), "response not found in - " + output);
+          assertTrue(output.contains("body:'{\n  \"errorCode\" : 1002,\n  \"message\" : \"Your Access Token is invalid.\",\n  \"refId\" :"), "response-body not found in - " + output);
+          assertTrue(output.contains("status:'HTTP/1.1 401 Unauthorized'"), "status not found in - " + output);
         }
     }
 }

--- a/src/test/java/com/smartsheet/api/sdk_test/AutomationRulesTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/AutomationRulesTest.java
@@ -22,14 +22,20 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
-import com.smartsheet.api.models.*;
+import com.smartsheet.api.models.AutomationAction;
+import com.smartsheet.api.models.AutomationRule;
+import com.smartsheet.api.models.PagedResult;
+import com.smartsheet.api.models.Recipient;
+import com.smartsheet.api.models.RecipientEmail;
 import com.smartsheet.api.models.enums.AutomationActionFrequency;
 import com.smartsheet.api.models.enums.AutomationActionType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AutomationRulesTest {
 
@@ -38,7 +44,7 @@ public class AutomationRulesTest {
         try {
             Smartsheet ss = HelperFunctions.SetupClient("List Automation Rules");
             PagedResult<AutomationRule> automationRules = ss.sheetResources().automationRuleResources().listAutomationRules(324, null);
-           Assertions.assertEquals(2, (long)automationRules.getTotalCount());
+          assertEquals(2, (long)automationRules.getTotalCount());
         } catch (Exception ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
         }
@@ -49,7 +55,7 @@ public class AutomationRulesTest {
         Smartsheet ss = HelperFunctions.SetupClient("Get Automation Rule");
         try {
             AutomationRule automationRule = ss.sheetResources().automationRuleResources().getAutomationRule(324, 284);
-           Assertions.assertEquals(284, (long)automationRule.getId());
+          assertEquals(284, (long)automationRule.getId());
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());

--- a/src/test/java/com/smartsheet/api/sdk_test/HelperFunctions.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/HelperFunctions.java
@@ -23,7 +23,7 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetBuilder;
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HelperFunctions {
 	public static Smartsheet SetupClient(String apiScenario){
@@ -37,6 +37,6 @@ public class HelperFunctions {
 		return ss;
 	}
 	public static void ExceptionMessage(String message, Throwable cause){
-		Assertions.fail(String.format("Exception: %s Detail: %s", message, cause));
+		fail(String.format("Exception: %s Detail: %s", message, cause));
 	}
 }

--- a/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/RowTest.java
@@ -8,9 +8,9 @@ package com.smartsheet.api.sdk_test;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,12 +22,21 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
-import com.smartsheet.api.models.*;
-import org.junit.jupiter.api.Assertions;
+import com.smartsheet.api.models.Cell;
+import com.smartsheet.api.models.CellLink;
+import com.smartsheet.api.models.Duration;
+import com.smartsheet.api.models.Hyperlink;
+import com.smartsheet.api.models.PagedResult;
+import com.smartsheet.api.models.Predecessor;
+import com.smartsheet.api.models.PredecessorList;
+import com.smartsheet.api.models.Row;
+import com.smartsheet.api.models.Sheet;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RowTest {
 
@@ -38,7 +47,7 @@ public class RowTest {
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
 			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(null, null, null);
-			Assertions.assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
+			assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -72,7 +81,7 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1L, Arrays.asList(rowA,rowB));
 
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -97,9 +106,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(1, addedRows.get(0).getRowNumber().intValue());
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
+			assertEquals(1, addedRows.get(0).getRowNumber().intValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -125,9 +134,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(100, addedRows.get(0).getRowNumber().intValue());
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals("Apple", addedRows.get(0).getCells().get(0).getValue());
+			assertEquals(100, addedRows.get(0).getRowNumber().intValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -161,8 +170,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
 
-			Assertions.assertEquals(100, addedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(100, addedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -196,9 +205,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
 
-			Assertions.assertEquals(10, addedRows.get(0).getId().intValue());
-			Assertions.assertEquals(true, addedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(10, addedRows.get(0).getId().intValue());
+			assertEquals(true, addedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -223,8 +232,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", addedRows.get(0).getCells().get(1).getFormula());
-			Assertions.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", addedRows.get(0).getCells().get(1).getFormula());
+			assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -255,9 +264,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Google", addedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals("http://google.com", addedRows.get(0).getCells().get(0).getHyperlink().getUrl());
+			assertEquals("Google", addedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals("http://google.com", addedRows.get(0).getCells().get(0).getHyperlink().getUrl());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -288,9 +297,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Sheet3", addedRows.get(0).getCells().get(1).getValue());
-			Assertions.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assertions.assertEquals(3L, addedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
+			assertEquals("Sheet3", addedRows.get(0).getCells().get(1).getValue());
+			assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals(3L, addedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -321,9 +330,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Report8", addedRows.get(0).getCells().get(1).getValue());
-			Assertions.assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assertions.assertEquals(8L, addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
+			assertEquals("Report8", addedRows.get(0).getCells().get(1).getValue());
+			assertEquals(102L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals(8L, addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -356,7 +365,7 @@ public class RowTest {
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assertions.assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
+			assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -382,7 +391,7 @@ public class RowTest {
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assertions.assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
+			assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -410,8 +419,8 @@ public class RowTest {
 
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(101L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assertions.assertEquals("2FS +2.5d", addedRows.get(0).getCells().get(1).getValue());
+			assertEquals(101L, addedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals("2FS +2.5d", addedRows.get(0).getCells().get(1).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -447,8 +456,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals("Apple", updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals("Apple", updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -484,8 +493,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals(100, updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(100, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -521,8 +530,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals(true, updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(true, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -548,8 +557,8 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", updatedRows.get(0).getCells().get(1).getFormula());
-			Assertions.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals("=SUM([Column2]3, [Column2]3, [Column2]4)", updatedRows.get(0).getCells().get(1).getFormula());
+			assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -581,9 +590,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Google", updatedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals("http://google.com", updatedRows.get(0).getCells().get(0).getHyperlink().getUrl());
+			assertEquals("Google", updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals("http://google.com", updatedRows.get(0).getCells().get(0).getHyperlink().getUrl());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -615,9 +624,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Sheet3", updatedRows.get(0).getCells().get(1).getValue());
-			Assertions.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assertions.assertEquals(3L, updatedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
+			assertEquals("Sheet3", updatedRows.get(0).getCells().get(1).getValue());
+			assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals(3L, updatedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -649,9 +658,9 @@ public class RowTest {
 			// Update rows in sheet
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals("Report8", updatedRows.get(0).getCells().get(1).getValue());
-			Assertions.assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
-			Assertions.assertEquals(8L, updatedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
+			assertEquals("Report8", updatedRows.get(0).getCells().get(1).getValue());
+			assertEquals(102L, updatedRows.get(0).getCells().get(1).getColumnId().longValue());
+			assertEquals(8L, updatedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -685,7 +694,7 @@ public class RowTest {
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assertions.assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
+			assertEquals("hyperlink.url must be null for sheet, report, or Sight hyperlinks.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -712,7 +721,7 @@ public class RowTest {
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assertions.assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
+			assertEquals("If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -733,8 +742,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -756,8 +765,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals(false, updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(false, updatedRows.get(0).getCells().get(0).getValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -780,9 +789,9 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getHyperlink());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(null, updatedRows.get(0).getCells().get(0).getHyperlink());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -805,9 +814,9 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
-			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
-			Assertions.assertEquals(null, updatedRows.get(0).getCells().get(0).getLinkInFromCell());
+			assertEquals(101L, updatedRows.get(0).getCells().get(0).getColumnId().longValue());
+			assertEquals(null, updatedRows.get(0).getCells().get(0).getValue());
+			assertEquals(null, updatedRows.get(0).getCells().get(0).getLinkInFromCell());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -838,7 +847,7 @@ public class RowTest {
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
-			Assertions.assertEquals("Only one of cell.hyperlink or cell.linkInFromCell may be non-null.", ex.getMessage());
+			assertEquals("Only one of cell.hyperlink or cell.linkInFromCell may be non-null.", ex.getMessage());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -856,8 +865,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(10L, updatedRows.get(0).getId().longValue());
-			Assertions.assertEquals(1L, updatedRows.get(0).getRowNumber().longValue());
+			assertEquals(10L, updatedRows.get(0).getId().longValue());
+			assertEquals(1L, updatedRows.get(0).getRowNumber().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -876,8 +885,8 @@ public class RowTest {
 
 			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assertions.assertEquals(10L, updatedRows.get(0).getId().longValue());
-			Assertions.assertEquals(100L, updatedRows.get(0).getRowNumber().longValue());
+			assertEquals(10L, updatedRows.get(0).getId().longValue());
+			assertEquals(100L, updatedRows.get(0).getRowNumber().longValue());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());

--- a/src/test/java/com/smartsheet/api/sdk_test/SheetTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/SheetTest.java
@@ -22,26 +22,28 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
-import com.smartsheet.api.models.*;
-
+import com.smartsheet.api.models.Column;
+import com.smartsheet.api.models.PagedResult;
+import com.smartsheet.api.models.Sheet;
 import com.smartsheet.api.models.enums.SourceInclusion;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 public class SheetTest {
 
-	
+
 	@Test
 	public void ListSheets_NoParams()
 	{
 		try {
 			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
 			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(null, null, null);
-			Assertions.assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
+			assertEquals("Copy of Sample Sheet", sheets.getData().get(0).getName());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -53,7 +55,7 @@ public class SheetTest {
 		try{
 			Smartsheet ss =  HelperFunctions.SetupClient("List Sheets - Include Owner Info");
 			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(EnumSet.of(SourceInclusion.OWNERINFO), null, null);
-			Assertions.assertEquals("john.doe@smartsheet.com", sheets.getData().get(0).getOwner());
+		assertEquals("john.doe@smartsheet.com", sheets.getData().get(0).getOwner());
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
 		}
@@ -71,7 +73,7 @@ public class SheetTest {
 			ss.sheetResources().createSheet(sheetA);
 
 		}catch(SmartsheetException ex){
-			Assertions.assertEquals("The new sheet requires either a fromId or columns.", ex.getMessage());
+		assertEquals("The new sheet requires either a fromId or columns.", ex.getMessage());
 
 		}catch(Exception ex){
 			HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());

--- a/src/test/java/com/smartsheet/api/sdk_test/SightsTest.java
+++ b/src/test/java/com/smartsheet/api/sdk_test/SightsTest.java
@@ -22,11 +22,15 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
-import com.smartsheet.api.models.*;
+import com.smartsheet.api.models.ContainerDestination;
+import com.smartsheet.api.models.PagedResult;
+import com.smartsheet.api.models.Sight;
+import com.smartsheet.api.models.SightPublish;
 import com.smartsheet.api.models.enums.DestinationType;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SightsTest {
 
@@ -35,7 +39,7 @@ public class SightsTest {
         try {
             Smartsheet ss = HelperFunctions.SetupClient("List Sights");
             PagedResult<Sight> sights = ss.sightResources().listSights(null, null);
-           Assertions.assertEquals(6, (long)sights.getTotalCount());
+          assertEquals(6, (long)sights.getTotalCount());
         } catch (Exception ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
         }
@@ -46,7 +50,7 @@ public class SightsTest {
         Smartsheet ss = HelperFunctions.SetupClient("Get Sight");
         try {
             Sight sight = ss.sightResources().getSight(52);
-           Assertions.assertEquals(52, (long)sight.getId());
+          assertEquals(52, (long)sight.getId());
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());
@@ -102,7 +106,7 @@ public class SightsTest {
         Smartsheet ss = HelperFunctions.SetupClient("Get Sight Publish Status");
         try {
             SightPublish publish = ss.sightResources().getPublishStatus(812L);
-           Assertions.assertEquals(publish.getReadOnlyFullEnabled(), true);
+          assertEquals(publish.getReadOnlyFullEnabled(), true);
         }
         catch(SmartsheetException ex) {
             HelperFunctions.ExceptionMessage(ex.getMessage(), ex.getCause());


### PR DESCRIPTION
Updates the `junit` assertions so that they all use the `static ... (method)"  import style rather than some using a nonstatic import of the upper level package and line items using the nested static assertion functions.