### PR TITLE
Make Gradle use the gpg-agent to Sign and Update GPG Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v1
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/build.gradle
+++ b/build.gradle
@@ -213,6 +213,9 @@ publishing {
 
 // Configuration for how we want to sign our Jar files
 signing {
+    // We will have the gpg-agent on the GitHub runner, so we want to use that key to sign
+    // Link: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent
+    useGpgCmd()
     // Specify that we want to sign our publications
     sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
- Updates from v1 to v5 of `crazy-max/ghaction-import-gpg` which loads our gpg key into memory.
- Tells Gradle to look for our gpg key using the gpg-agent command since we already have it loaded there