### PR TITLE
Fix Release to Sonatype

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish package
-        run: ./gradlew publish
+        run: ./gradlew publish -i
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -24,7 +24,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish package
-        run: ./gradlew publishToSonatype closeSonatypeStagingRepository -i
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -i
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -15,7 +15,16 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Run Unit Tests
+          server-id: deployment
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v1
         env:
-          SMARTSHEET_ACCESS_TOKEN: ${{secrets.SMARTSHEET_ACCESS_TOKEN}}
-        run: ./gradlew clean test jacocoTestReport
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Publish package
+        run: ./gradlew publishToSonatype closeSonatypeStagingRepository -i
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -15,16 +15,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          server-id: deployment
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v1
+      - name: Run Unit Tests
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Publish package
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -i
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          SMARTSHEET_ACCESS_TOKEN: ${{secrets.SMARTSHEET_ACCESS_TOKEN}}
+        run: ./gradlew clean test jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'signing'
     // Allows us to publish our artifact
     id 'maven-publish'
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 
     // ** MAINTENANCE PLUGINS **
     // Allows us to run `./gradlew dependencyUpdates` to check for dependency updates
@@ -34,7 +35,7 @@ plugins {
 
 // Project Settings
 group = 'com.smartsheet'
-version = '3.1.2'
+version = '3.1.2-SNAPSHOT'
 sourceCompatibility = '11'
 
 // Variables to expose
@@ -197,19 +198,17 @@ publishing {
         }
     }
 
-    // Maven Repo configuration for publishing our Jars
+}
+
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
-            }
+        sonatype {
+            username = System.getenv("MAVEN_USERNAME")
+            password = System.getenv("MAVEN_PASSWORD")
         }
     }
 }
+
 
 // Configuration for how we want to sign our Jar files
 signing {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'signing'
     // Allows us to publish our artifact
     id 'maven-publish'
+    // Allows us to publish to https://oss.sonatype.org/ and release our artifact
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 
     // ** MAINTENANCE PLUGINS **
@@ -164,6 +165,7 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+            // Details that will be included in our published POM file
             pom {
                 name = 'Smartsheet Java SDK'
                 description = 'Library for connecting to Smartsheet Services'
@@ -200,6 +202,7 @@ publishing {
 
 }
 
+// The credentials for us to publish to https://oss.sonatype.org/ and release our artifact
 nexusPublishing {
     repositories {
         sonatype {

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ plugins {
 
 // Project Settings
 group = 'com.smartsheet'
-version = '3.1.2-SNAPSHOT'
+version = '3.1.2'
 sourceCompatibility = '11'
 
 // Variables to expose


### PR DESCRIPTION
Previous our release was not publishing to Sonatype correctly. This adds a new plugin that will help us publish and release to Sonatype.

We can see it works as 3.1.2 is correctly published now. https://mvnrepository.com/artifact/com.smartsheet/smartsheet-sdk-java