### PR TITLE
Fix Checkstyle Violations in "Impl" Classes

### DIFF
--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -76,6 +76,9 @@ public abstract class AbstractResources {
     /** The Constant BUFFER_SIZE. */
     private static final int BUFFER_SIZE = 4098;
 
+    private static final String JSON_CONTENT_TYPE = "application/json";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+
     /**
      * The Enum ErrorCode.
      */
@@ -275,7 +278,7 @@ public abstract class AbstractResources {
         ByteArrayOutputStream objectBytesStream = new ByteArrayOutputStream();
         this.smartsheet.getJsonSerializer().serialize(object, objectBytesStream);
         HttpEntity entity = new HttpEntity();
-        entity.setContentType("application/json");
+        entity.setContentType(JSON_CONTENT_TYPE);
         entity.setContent(new ByteArrayInputStream(objectBytesStream.toByteArray()));
         entity.setContentLength(objectBytesStream.size());
         request.setEntity(entity);
@@ -349,7 +352,7 @@ public abstract class AbstractResources {
         HttpPost uploadFile = createHttpPost(this.getSmartsheet().getBaseURI().resolve(path));
 
         try {
-            uploadFile.setHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+            uploadFile.setHeader(HEADER_CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -404,7 +407,7 @@ public abstract class AbstractResources {
         ByteArrayOutputStream objectBytesStream = new ByteArrayOutputStream();
         this.smartsheet.getJsonSerializer().serialize(object, objectBytesStream);
         HttpEntity entity = new HttpEntity();
-        entity.setContentType("application/json");
+        entity.setContentType(JSON_CONTENT_TYPE);
         entity.setContent(new ByteArrayInputStream(objectBytesStream.toByteArray()));
         entity.setContentLength(objectBytesStream.size());
         request.setEntity(entity);
@@ -616,7 +619,7 @@ public abstract class AbstractResources {
         ByteArrayOutputStream objectBytesStream = new ByteArrayOutputStream();
         this.smartsheet.getJsonSerializer().serialize(objectToPost, objectBytesStream);
         HttpEntity entity = new HttpEntity();
-        entity.setContentType("application/json");
+        entity.setContentType(JSON_CONTENT_TYPE);
         entity.setContent(new ByteArrayInputStream(objectBytesStream.toByteArray()));
         entity.setContentLength(objectBytesStream.size());
         request.setEntity(entity);
@@ -668,7 +671,7 @@ public abstract class AbstractResources {
         ByteArrayOutputStream objectBytesStream = new ByteArrayOutputStream();
         this.smartsheet.getJsonSerializer().serialize(objectToPost, objectBytesStream);
         HttpEntity entity = new HttpEntity();
-        entity.setContentType("application/json");
+        entity.setContentType(JSON_CONTENT_TYPE);
         entity.setContent(new ByteArrayInputStream(objectBytesStream.toByteArray()));
         entity.setContentLength(objectBytesStream.size());
         request.setEntity(entity);
@@ -716,7 +719,7 @@ public abstract class AbstractResources {
         ByteArrayOutputStream objectBytesStream = new ByteArrayOutputStream();
         this.smartsheet.getJsonSerializer().serialize(objectToPut, objectBytesStream);
         HttpEntity entity = new HttpEntity();
-        entity.setContentType("application/json");
+        entity.setContentType(JSON_CONTENT_TYPE);
         entity.setContent(new ByteArrayInputStream(objectBytesStream.toByteArray()));
         entity.setContentLength(objectBytesStream.size());
         request.setEntity(entity);
@@ -765,6 +768,9 @@ public abstract class AbstractResources {
         return httpPost;
     }
 
+    /**
+     * Attach a file
+     */
     public Attachment attachFile(String url, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
@@ -818,7 +824,7 @@ public abstract class AbstractResources {
         HttpPost uploadFile = createHttpPost(this.getSmartsheet().getBaseURI().resolve(url));
 
         try {
-            uploadFile.setHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+            uploadFile.setHeader(HEADER_CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -957,7 +963,7 @@ public abstract class AbstractResources {
     Map<String, String> createHeaders() {
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", "Bearer " + smartsheet.getAccessToken());
-        headers.put("Content-Type", "application/json");
+        headers.put(HEADER_CONTENT_TYPE, JSON_CONTENT_TYPE);
 
         // Set assumed user
         if (smartsheet.getAssumedUser() != null) {

--- a/src/main/java/com/smartsheet/api/internal/AssociatedAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/AssociatedAttachmentResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,8 +31,7 @@ import java.util.List;
  * @deprecated As of release 2.0
  */
 @Deprecated
-public class AssociatedAttachmentResourcesImpl extends AbstractAssociatedResources
-    implements AssociatedAttachmentResources {
+public class AssociatedAttachmentResourcesImpl extends AbstractAssociatedResources implements AssociatedAttachmentResources {
 
     /**
      * @deprecated As of release 2.0
@@ -46,7 +45,7 @@ public class AssociatedAttachmentResourcesImpl extends AbstractAssociatedResourc
      * @deprecated As of release 2.0
      */
     @Deprecated
-    public List<Attachment> listAttachments(long objectId){
+    public List<Attachment> listAttachments(long objectId) {
         throw new UnsupportedOperationException();
     }
 
@@ -54,26 +53,23 @@ public class AssociatedAttachmentResourcesImpl extends AbstractAssociatedResourc
      * @deprecated As of release 2.0
      */
     @Deprecated
-    public Attachment attachFile(long objectId, File file, String contentType){
+    public Attachment attachFile(long objectId, File file, String contentType) {
         throw new UnsupportedOperationException();
     }
-
 
     /**
      * @deprecated As of release 2.0
      */
     @Deprecated
-    public Attachment attachFile(long objectId, InputStream inputStream, String contentType, long contentLength, String attachmentName){
+    public Attachment attachFile(long objectId, InputStream inputStream, String contentType, long contentLength, String attachmentName) {
         throw new UnsupportedOperationException();
     }
-
 
     /**
      * @deprecated As of release 2.0
      */
     @Deprecated
-    public Attachment attachURL(long objectId, Attachment attachment){
+    public Attachment attachURL(long objectId, Attachment attachment) {
         throw new UnsupportedOperationException();
     }
-
 }

--- a/src/main/java/com/smartsheet/api/internal/AssociatedDiscussionResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/AssociatedDiscussionResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.AssociatedDiscussionResources;
 import com.smartsheet.api.SmartsheetException;
@@ -31,15 +29,14 @@ import com.smartsheet.api.models.Discussion;
  * @deprecated As of release 2.0
  */
 @Deprecated
-public class AssociatedDiscussionResourcesImpl extends AbstractAssociatedResources 
-    implements AssociatedDiscussionResources {
+public class AssociatedDiscussionResourcesImpl extends AbstractAssociatedResources implements AssociatedDiscussionResources {
 
     /**
      * @deprecated As of release 2.0
      */
     @Deprecated
     public AssociatedDiscussionResourcesImpl(SmartsheetImpl smartsheet, String masterResourceType) {
-        super(smartsheet,masterResourceType);
+        super(smartsheet, masterResourceType);
     }
 
     /**

--- a/src/main/java/com/smartsheet/api/internal/AttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/AttachmentResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,6 @@ package com.smartsheet.api.internal;
  * %[license]
  */
 
-
 import com.smartsheet.api.AttachmentResources;
 import com.smartsheet.api.models.Attachment;
 
@@ -28,17 +27,17 @@ import java.io.File;
 import java.io.InputStream;
 
 /**
- * @deprecated As of release 2.0
  * This is the implementation of the AttachmentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
+ * @deprecated As of release 2.0
  */
 @Deprecated
 public class AttachmentResourcesImpl extends AbstractResources implements AttachmentResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -48,21 +47,26 @@ public class AttachmentResourcesImpl extends AbstractResources implements Attach
     }
 
     /**
-     * @deprecated As of release 2.0
      * @return the attachment
+     * @deprecated As of release 2.0
      */
     @Deprecated
-    public Attachment attachNewVersion(long attachmentId, File file, String contentType){
+    public Attachment attachNewVersion(long attachmentId, File file, String contentType) {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * @deprecated As of release 2.0
      * @return the attachment
+     * @deprecated As of release 2.0
      */
     @Deprecated
-    public Attachment attachNewVersion (long attachmentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
-    {
+    public Attachment attachNewVersion(
+            long attachmentId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/AttachmentVersioningResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/AttachmentVersioningResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,16 +35,17 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+
 /**
  * This is the implementation of the AssociatedAttachmentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class AttachmentVersioningResourcesImpl extends AbstractResources implements AttachmentVersioningResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null or empty string
      *
@@ -55,7 +57,7 @@ public class AttachmentVersioningResourcesImpl extends AbstractResources impleme
 
     /**
      * Deletes an attachment, including all of its versions.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/attachments/{attachmentId}/versions
      *
      * @param sheetId the sheet id
@@ -67,20 +69,21 @@ public class AttachmentVersioningResourcesImpl extends AbstractResources impleme
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public void deleteAllVersions(long sheetId, long attachentId) throws SmartsheetException{
-        this.deleteResource("sheets/"+ sheetId+ "/attachments/"+ attachentId + "/versions", Attachment.class);
+    public void deleteAllVersions(long sheetId, long attachentId) throws SmartsheetException {
+        // Note: "attachentId" has a typo in it here, but it'd be a breaking change to rename it since this is public
+        this.deleteResource(createPath(sheetId, attachentId), Attachment.class);
     }
 
     /**
      * Get all versions of an attachment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/attachments/{attachmentId}/versions
      *
      * @param sheetId the id
      * @param attachmentId the attachment id
      * @param parameters the pagination paramaters
      * @return the attachment (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -88,8 +91,12 @@ public class AttachmentVersioningResourcesImpl extends AbstractResources impleme
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public PagedResult<Attachment> listAllVersions(long sheetId, long attachmentId, PaginationParameters parameters) throws SmartsheetException {
-        String path = "sheets/"+ sheetId + "/attachments/" + attachmentId + "/versions";
+    public PagedResult<Attachment> listAllVersions(
+            long sheetId,
+            long attachmentId,
+            PaginationParameters parameters
+    ) throws SmartsheetException {
+        String path = createPath(sheetId, attachmentId);
 
         if (parameters != null) {
             path += parameters.toQueryString();
@@ -115,16 +122,21 @@ public class AttachmentVersioningResourcesImpl extends AbstractResources impleme
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Attachment attachNewVersion(long sheetId ,long attachmentId, File file, String contentType) throws FileNotFoundException, SmartsheetException {
+    public Attachment attachNewVersion(
+            long sheetId,
+            long attachmentId,
+            File file,
+            String contentType
+    ) throws FileNotFoundException, SmartsheetException {
         Util.throwIfNull(attachmentId, file, contentType);
         Util.throwIfEmpty(contentType);
 
-        return attachNewVersion(sheetId ,attachmentId, new FileInputStream(file), contentType, file.length(), file.getName());
+        return attachNewVersion(sheetId, attachmentId, new FileInputStream(file), contentType, file.length(), file.getName());
     }
 
     /**
      * Attach a new version of an attachment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /attachment/{id}/versions
      *
      * @param sheetId the id of the sheet
@@ -141,8 +153,24 @@ public class AttachmentVersioningResourcesImpl extends AbstractResources impleme
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    private Attachment attachNewVersion (long sheetId, long attachmentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
-            throws SmartsheetException {
-        return super.attachFile("sheets/"+ sheetId + "/attachments/"+ attachmentId +"/versions", inputStream, contentType, contentLength, attachmentName);
+    private Attachment attachNewVersion(
+            long sheetId,
+            long attachmentId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) throws SmartsheetException {
+        return super.attachFile(
+                createPath(sheetId, attachmentId),
+                inputStream,
+                contentType,
+                contentLength,
+                attachmentName
+        );
+    }
+
+    private String createPath(long sheetId, long attachmentId) {
+        return "sheets/" + sheetId + "/attachments/" + attachmentId + "/versions";
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/ColumnResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/ColumnResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,14 @@ package com.smartsheet.api.internal;
  * %[license]
  */
 
-
 import com.smartsheet.api.ColumnResources;
 import com.smartsheet.api.models.Column;
 
 /**
- * @deprecated As of release 2.0
  * This is the implementation of the ColumnResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
+ * @deprecated As of release 2.0
  */
 @Deprecated
 public class ColumnResourcesImpl implements ColumnResources {

--- a/src/main/java/com/smartsheet/api/internal/CommentAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/CommentAttachmentResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@ import java.io.InputStream;
  *
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class CommentAttachmentResourcesImpl extends AbstractResources implements com.smartsheet.api.CommentAttachmentResources{
+public class CommentAttachmentResourcesImpl extends AbstractResources implements com.smartsheet.api.CommentAttachmentResources {
 
     public CommentAttachmentResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
@@ -63,8 +63,7 @@ public class CommentAttachmentResourcesImpl extends AbstractResources implements
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Attachment attachUrl(long sheetId, long commentId, Attachment attachment) throws SmartsheetException
-    {
+    public Attachment attachUrl(long sheetId, long commentId, Attachment attachment) throws SmartsheetException {
         return this.createResource("sheets/" + sheetId + "/comments/" + commentId + "/attachments", Attachment.class, attachment);
     }
 
@@ -106,9 +105,22 @@ public class CommentAttachmentResourcesImpl extends AbstractResources implements
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFile(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
-            throws SmartsheetException {
+    public Attachment attachFile(
+            long sheetId,
+            long commentId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
-        return super.attachFile("sheets/" + sheetId + "/comments/" + commentId + "/attachments", inputStream, contentType, contentLength, attachmentName);
+
+        return super.attachFile(
+                "sheets/" + sheetId + "/comments/" + commentId + "/attachments",
+                inputStream,
+                contentType,
+                contentLength,
+                attachmentName
+        );
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/CommentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/CommentResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,8 @@ import com.smartsheet.api.models.Comment;
  */
 @Deprecated
 public class CommentResourcesImpl extends AbstractResources implements CommentResources {
+    private static final String METHOD_MOVED_MESSAGE = "Method moved to SheetCommentResources.";
+
     /**
      * @deprecated As of release 2.0
      */
@@ -42,7 +44,7 @@ public class CommentResourcesImpl extends AbstractResources implements CommentRe
      */
     @Deprecated
     public AssociatedAttachmentResources attachments() {
-        throw new UnsupportedOperationException("Method moved to SheetCommentResources.");
+        throw new UnsupportedOperationException(METHOD_MOVED_MESSAGE);
     }
 
     /**
@@ -50,7 +52,7 @@ public class CommentResourcesImpl extends AbstractResources implements CommentRe
      */
     @Deprecated
     public Comment getComment(long sheetId, long commentId) {
-        throw new UnsupportedOperationException("Method moved to SheetCommentResources.");
+        throw new UnsupportedOperationException(METHOD_MOVED_MESSAGE);
     }
 
     /**
@@ -58,6 +60,6 @@ public class CommentResourcesImpl extends AbstractResources implements CommentRe
      */
     @Deprecated
     public void deleteComment(long sheetId, long commentId) {
-        throw new UnsupportedOperationException("Method moved to SheetCommentResources.");
+        throw new UnsupportedOperationException(METHOD_MOVED_MESSAGE);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/ContactResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/ContactResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,8 @@ import com.smartsheet.api.models.PaginationParameters;
 /**
  * This is the implementation of the ContactResources.
  */
-public class ContactResourcesImpl extends AbstractResources implements ContactResources{
+public class ContactResourcesImpl extends AbstractResources implements ContactResources {
+
     /**
      * Constructor
      *
@@ -43,28 +44,26 @@ public class ContactResourcesImpl extends AbstractResources implements ContactRe
 
     /**
      * Gets the specified Contact.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /contacts/{contactId}
      *
      * @param contactId the ID of the contact
      * @return the contact object
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Contact getContact(String contactId) throws SmartsheetException{
+    public Contact getContact(String contactId) throws SmartsheetException {
         return this.getResource("contacts/" + contactId, Contact.class);
     }
 
-
     /**
      * Gets a list of the user’s Smartsheet Contacts.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /contacts
      *
      * @param parameters the pagination parameters
      * @return the contacts as a paged list
-     * @throws SmartsheetException
      */
-    public PagedResult<Contact> listContacts(PaginationParameters parameters) throws SmartsheetException{
+    public PagedResult<Contact> listContacts(PaginationParameters parameters) throws SmartsheetException {
         String path = "contacts";
 
         if (parameters != null) {

--- a/src/main/java/com/smartsheet/api/internal/DiscussionAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/internal/DiscussionAttachmentResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,6 @@ package com.smartsheet.api.internal;
  * %[license]
  */
 
-
 import com.smartsheet.api.models.Attachment;
 
 import java.io.File;
@@ -28,17 +27,17 @@ import java.io.InputStream;
 
 /**
  * This is the implementation of the AssociatedAttachmentResources for discussions.
- *
+ * <p>
  * It extends AssociatedAttachmentResourcesImpl and overrides attachFile/attachURL methods by throwing
  * UnsupportedOperationException (since they're not supported for discussions).
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class DiscussionAttachmentResources extends AssociatedAttachmentResourcesImpl {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null or empty string
      *
      * @param smartsheet the smartsheet
@@ -49,14 +48,14 @@ public class DiscussionAttachmentResources extends AssociatedAttachmentResources
 
     /**
      * Attach a file to the object.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method:
      *     POST /sheet/{id}/attachments
      *     POST /row/{id}/attachments
      *     POST /comment/{id}/attachments
-     *
+     * <p>
      * Returns: the created attachment
-     *
+     * <p>
      * Exceptions:
      *   UnsupportedOperationException : this exception is always thrown since this method is not supported by
      *   discussion resources.

--- a/src/main/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/DiscussionAttachmentResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,16 +25,17 @@ import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.Attachment;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
+
 /**
  * This is the implementation of the DiscussionAttachmentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class DiscussionAttachmentResourcesImpl extends AbstractResources implements DiscussionAttachmentResources{
+public class DiscussionAttachmentResourcesImpl extends AbstractResources implements DiscussionAttachmentResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -44,9 +46,9 @@ public class DiscussionAttachmentResourcesImpl extends AbstractResources impleme
 
     /**
      * Get discussion attachment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/discussions/{discussionId}/attachments
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -59,11 +61,15 @@ public class DiscussionAttachmentResourcesImpl extends AbstractResources impleme
      * @param discussionId the discussion id
      * @param parameters the pagination parameters
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<Attachment> getAttachments(long sheetId, long discussionId, PaginationParameters parameters) throws SmartsheetException {
-        String path= "sheets/" + sheetId + "/discussions/" + discussionId + "/attachments";
+    public PagedResult<Attachment> getAttachments(
+            long sheetId,
+            long discussionId,
+            PaginationParameters parameters
+    ) throws SmartsheetException {
+        String path = "sheets/" + sheetId + "/discussions/" + discussionId + "/attachments";
         if (parameters != null) {
             path += parameters.toQueryString();
         }

--- a/src/main/java/com/smartsheet/api/internal/DiscussionCommentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/DiscussionCommentResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -32,16 +33,18 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
 /**
  * This is the implementation of the DiscussionCommentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class DiscussionCommentResourcesImpl extends AbstractResources implements DiscussionCommentResources{
+public class DiscussionCommentResourcesImpl extends AbstractResources implements DiscussionCommentResources {
+    private static final String SHEETS_PATH = "sheets/";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -66,8 +69,8 @@ public class DiscussionCommentResourcesImpl extends AbstractResources implements
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Comment addComment(long sheetId, long discussionId, Comment comment) throws SmartsheetException{
-        return this.createResource("sheets/" + sheetId + "/discussions/" + discussionId + "/comments", Comment.class, comment);
+    public Comment addComment(long sheetId, long discussionId, Comment comment) throws SmartsheetException {
+        return this.createResource(SHEETS_PATH + sheetId + "/discussions/" + discussionId + "/comments", Comment.class, comment);
     }
 
     /**
@@ -89,15 +92,27 @@ public class DiscussionCommentResourcesImpl extends AbstractResources implements
      * @throws SmartsheetException if there is any other error during the operation
      * @throws IOException is there is any error with file
      */
-    public Comment addCommentWithAttachment(long sheetId, long discussionId, Comment comment, File file, String contentType) throws SmartsheetException, IOException{
-        String path = "sheets/" + sheetId + "/discussions/" + discussionId + "/comments";
+    public Comment addCommentWithAttachment(
+            long sheetId,
+            long discussionId,
+            Comment comment,
+            File file,
+            String contentType
+    ) throws SmartsheetException, IOException {
+        String path = SHEETS_PATH + sheetId + "/discussions/" + discussionId + "/comments";
         Util.throwIfNull(sheetId, comment, file, contentType);
 
         return this.addCommentWithAttachment(path, comment, new FileInputStream(file), contentType, file.getName());
     }
 
-    private Comment addCommentWithAttachment(String path, Comment comment, InputStream inputStream, String contentType, String attachmentName) throws SmartsheetException{
-        return this.createResourceWithAttachment(path, Comment.class, comment, "comment", inputStream , contentType, attachmentName);
+    private Comment addCommentWithAttachment(
+            String path,
+            Comment comment,
+            InputStream inputStream,
+            String contentType,
+            String attachmentName
+    ) throws SmartsheetException {
+        return this.createResourceWithAttachment(path, Comment.class, comment, "comment", inputStream, contentType, attachmentName);
     }
 
     /**
@@ -116,6 +131,6 @@ public class DiscussionCommentResourcesImpl extends AbstractResources implements
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Comment updateComment(long sheetId, Comment comment) throws SmartsheetException {
-        return this.updateResource("sheets/" + sheetId + "/comments/" + comment.getId(), Comment.class, comment);
+        return this.updateResource(SHEETS_PATH + sheetId + "/comments/" + comment.getId(), Comment.class, comment);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/DiscussionResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/DiscussionResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.AssociatedAttachmentResources;
 import com.smartsheet.api.DiscussionCommentResources;
@@ -29,27 +28,27 @@ import com.smartsheet.api.models.Comment;
 
 /**
  * This is the implementation of the DiscussionResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class DiscussionResourcesImpl extends AbstractResources implements DiscussionResources {
     /**
      * Represents the AssociatedAttachmentResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private AssociatedAttachmentResources attachments;
 
     /**
      * Represents the DiscussionCommentResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private DiscussionCommentResources comments;
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -60,9 +59,9 @@ public class DiscussionResourcesImpl extends AbstractResources implements Discus
 
     /**
      * Add a comment to a discussion.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /discussion/{discussionId}/comments
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request

--- a/src/main/java/com/smartsheet/api/internal/EventResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/EventResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.AuthorizationException;
 import com.smartsheet.api.EventResources;
@@ -40,7 +39,7 @@ import java.util.Map;
 
 /**
  * This is the implementation of the SheetResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class EventResourcesImpl extends AbstractResources implements EventResources {
@@ -83,11 +82,10 @@ public class EventResourcesImpl extends AbstractResources implements EventResour
         String path = "events";
 
         Map<String, Object> parameters = new HashMap<>();
-        if(since instanceof Date) {
+        if (since instanceof Date) {
             String isoDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(since);
             parameters.put("since", isoDate);
-        }
-        else {
+        } else {
             parameters.put("since", since);
         }
         parameters.put("streamPosition", streamPosition);

--- a/src/main/java/com/smartsheet/api/internal/FavoriteResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/FavoriteResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,14 +35,14 @@ import java.util.Set;
 
 /**
  * This is the implementation of the FavoriteResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class FavoriteResourcesImpl extends AbstractResources implements FavoriteResources{
+public class FavoriteResourcesImpl extends AbstractResources implements FavoriteResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -53,9 +53,9 @@ public class FavoriteResourcesImpl extends AbstractResources implements Favorite
 
     /**
      * Adds one or more items to the user's list of Favorite items.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /favorites
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -66,19 +66,19 @@ public class FavoriteResourcesImpl extends AbstractResources implements Favorite
      *   SmartsheetException : if there is any other error occurred during the operation
      *
      * @param favorites the list of favorites object limited to the following attributes: *
-     * objectId * type
+     *     objectId * type
      * @return a single Favorite object or an array of Favorite objects
      * @throws SmartsheetException the smartsheet exception
      */
-    public List<Favorite> addFavorites(List<Favorite> favorites) throws SmartsheetException{
+    public List<Favorite> addFavorites(List<Favorite> favorites) throws SmartsheetException {
         return this.postAndReceiveList("favorites/", favorites, Favorite.class);
     }
 
     /**
      * Gets a list of all the user's Favorite items.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /favorites
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -92,7 +92,7 @@ public class FavoriteResourcesImpl extends AbstractResources implements Favorite
      * @return a single Favorite object or an array of Favorite objects
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<Favorite> listFavorites(PaginationParameters parameters) throws SmartsheetException{
+    public PagedResult<Favorite> listFavorites(PaginationParameters parameters) throws SmartsheetException {
         String path = "favorites";
 
         if (parameters != null) {
@@ -104,9 +104,9 @@ public class FavoriteResourcesImpl extends AbstractResources implements Favorite
 
     /**
      * Deletes a list of favorites (all the same type)
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /favorites
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -120,7 +120,7 @@ public class FavoriteResourcesImpl extends AbstractResources implements Favorite
      * @param objectIds a single Favorite object or an array of Favorite objects
      * @throws SmartsheetException the smartsheet exception
      */
-    public void removeFavorites(FavoriteType favoriteType, Set<Long> objectIds) throws SmartsheetException{
+    public void removeFavorites(FavoriteType favoriteType, Set<Long> objectIds) throws SmartsheetException {
         String path = "favorites/" + favoriteType.toString();
         Map<String, Object> parameters = new HashMap<>();
 

--- a/src/main/java/com/smartsheet/api/internal/FolderResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/FolderResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,16 +38,17 @@ import java.util.Map;
 
 /**
  * This is the implementation of the FolderResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class FolderResourcesImpl extends AbstractResources implements FolderResources {
+    private static final String FOLDERS_PATH = "folders/";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Parameters: - smartsheet : the SmartsheetImpl
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -58,9 +59,9 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
 
     /**
      * Get a folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /folder/{id}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -72,11 +73,11 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      * @param folderId the folder id
      * @param includes the include parameters
      * @return the folder (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws SmartsheetException the smartsheet exception
      */
     public Folder getFolder(long folderId, EnumSet<SourceInclusion> includes) throws SmartsheetException {
-        String path = "folders/" + folderId;
+        String path = FOLDERS_PATH + folderId;
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
         path += QueryUtil.generateUrl(null, parameters);
@@ -86,9 +87,9 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
 
     /**
      * Update a folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /folder/{id}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -100,19 +101,19 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      *
      * @param folder the folder to update
      * @return the updated folder (note that if there is no such folder, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *      ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Folder updateFolder(Folder folder) throws SmartsheetException {
 
-        return this.updateResource("folders/" + folder.getId(), Folder.class, folder);
+        return this.updateResource(FOLDERS_PATH + folder.getId(), Folder.class, folder);
     }
 
     /**
      * Delete a folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /folder{id}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -126,16 +127,16 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      */
     public void deleteFolder(long folderId) throws SmartsheetException {
 
-        this.deleteResource("folders/" + folderId, Folder.class);
+        this.deleteResource(FOLDERS_PATH + folderId, Folder.class);
     }
 
     /**
      * List child folders of a given folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /folder/{id}/folders
-     *
+     * <p>
      * Parameters: - parentFolderId : the parent folder ID
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -150,7 +151,7 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<Folder> listFolders(long parentFolderId, PaginationParameters parameters) throws SmartsheetException {
-        String path = "folders/" + parentFolderId + "/folders";
+        String path = FOLDERS_PATH + parentFolderId + "/folders";
 
         if (parameters != null) {
             path += parameters.toQueryString();
@@ -161,9 +162,9 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
 
     /**
      * Create a folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /folder/{id}/folders
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -179,14 +180,14 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      */
     public Folder createFolder(long parentFolderId, Folder folder) throws SmartsheetException {
 
-        return this.createResource("folders/" + parentFolderId + "/folders", Folder.class, folder);
+        return this.createResource(FOLDERS_PATH + parentFolderId + "/folders", Folder.class, folder);
     }
 
     /**
      * Creates a copy of the specified Folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /folders/{folderId}/copy
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -202,15 +203,20 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      * @return the folder
      * @throws SmartsheetException the smartsheet exception
      */
-    public Folder copyFolder(long folderId, ContainerDestination containerDestination, EnumSet<FolderCopyInclusion> includes, EnumSet<FolderRemapExclusion> skipRemap) throws SmartsheetException {
+    public Folder copyFolder(
+            long folderId,
+            ContainerDestination containerDestination,
+            EnumSet<FolderCopyInclusion> includes,
+            EnumSet<FolderRemapExclusion> skipRemap
+    ) throws SmartsheetException {
         return copyFolder(folderId, containerDestination, includes, skipRemap, null);
     }
 
     /**
      * Creates a copy of the specified Folder.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /folders/{folderId}/copy
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -230,7 +236,7 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
     public Folder copyFolder(long folderId, ContainerDestination containerDestination, EnumSet<FolderCopyInclusion> includes,
                              EnumSet<FolderRemapExclusion> skipRemap, EnumSet<CopyExclusion> excludes) throws SmartsheetException {
 
-        String path = "folders/" + folderId + "/copy";
+        String path = FOLDERS_PATH + folderId + "/copy";
         Map<String, Object> parameters = new HashMap<>();
 
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
@@ -244,9 +250,9 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
 
     /**
      * Moves the specified Folder to another location.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /folders/{folderId}/move
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -262,7 +268,7 @@ public class FolderResourcesImpl extends AbstractResources implements FolderReso
      */
     public Folder moveFolder(long folderId, ContainerDestination containerDestination) throws SmartsheetException {
 
-        String path = "folders/" + folderId + "/move";
+        String path = FOLDERS_PATH + folderId + "/move";
         return this.createResource(path, Folder.class, containerDestination);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/GroupMemberResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/GroupMemberResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/internal/GroupResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/GroupResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.GroupMemberResources;
 import com.smartsheet.api.GroupResources;
@@ -31,14 +30,17 @@ import com.smartsheet.api.models.PaginationParameters;
 
 /**
  * This is the implementation of the HomeResources.
- * 
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class GroupResourcesImpl extends AbstractResources implements GroupResources {
     private GroupMemberResources groupMemberResources;
+
+    private static final String GROUPS = "groups";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -50,7 +52,7 @@ public class GroupResourcesImpl extends AbstractResources implements GroupResour
 
     @Override
     public PagedResult<Group> listGroups(PaginationParameters paging) throws SmartsheetException {
-        String path = "groups";
+        String path = GROUPS;
 
         if (paging != null) {
             path += paging.toQueryString();
@@ -61,34 +63,34 @@ public class GroupResourcesImpl extends AbstractResources implements GroupResour
 
     @Override
     public Group getGroup(long groupId) throws SmartsheetException {
-        return this.getResource("groups/" + groupId, Group.class);
+        return this.getResource(GROUPS + "/" + groupId, Group.class);
     }
 
     @Override
     public Group createGroup(Group group) throws SmartsheetException {
         Util.throwIfNull(group);
-        return this.createResource("groups", Group.class, group);
+        return this.createResource(GROUPS, Group.class, group);
     }
 
     @Override
     public Group updateGroup(Group group) throws SmartsheetException {
         Util.throwIfNull(group);
-        return this.updateResource("groups/"+ group.getId(), Group.class, group);
+        return this.updateResource(GROUPS + "/" + group.getId(), Group.class, group);
     }
 
     @Override
     public void deleteGroup(long groupId) throws SmartsheetException {
-        this.deleteResource("groups/" + groupId, Group.class);
+        this.deleteResource(GROUPS + "/" + groupId, Group.class);
     }
 
-    @Override
     /**
      * Represents the GroupMemberResources.
-     * It will be initialized in constructor and will not change afterwards.
+     * It will be initialized in constructor and will not change afterward.
      *
      * @return members object
      * @throws SmartsheetException if there is any other error during the operation
      */
+    @Override
     public GroupMemberResources memberResources() throws SmartsheetException {
         return groupMemberResources;
     }

--- a/src/main/java/com/smartsheet/api/internal/HomeFolderResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/HomeFolderResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.HomeFolderResources;
 import com.smartsheet.api.SmartsheetException;
@@ -30,14 +28,14 @@ import com.smartsheet.api.models.PaginationParameters;
 
 /**
  * This is the implementation of the HomeFolderResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class HomeFolderResourcesImpl extends AbstractResources implements HomeFolderResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -48,9 +46,9 @@ public class HomeFolderResourcesImpl extends AbstractResources implements HomeFo
 
     /**
      * List folders under home.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /home/folders
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -75,9 +73,9 @@ public class HomeFolderResourcesImpl extends AbstractResources implements HomeFo
 
     /**
      * Create a folder in home.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /home/folders
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request

--- a/src/main/java/com/smartsheet/api/internal/HomeResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/HomeResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.HomeFolderResources;
 import com.smartsheet.api.HomeResources;
@@ -35,20 +34,20 @@ import java.util.Map;
 
 /**
  * This is the implementation of the HomeResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class HomeResourcesImpl extends AbstractResources implements HomeResources {
     /**
      * Represents the HomeFolderResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private HomeFolderResources folders;
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -61,9 +60,9 @@ public class HomeResourcesImpl extends AbstractResources implements HomeResource
     /**
      * Get a nested list of all Home objects, including sheets, workspaces and folders, and optionally reports and/or
      * templates, as shown on the Home tab..
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /home
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -74,7 +73,7 @@ public class HomeResourcesImpl extends AbstractResources implements HomeResource
      *
      * @param includes used to specify the optional objects to include, currently TEMPLATES is supported.
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Home getHome(EnumSet<SourceInclusion> includes) throws SmartsheetException {
@@ -84,9 +83,9 @@ public class HomeResourcesImpl extends AbstractResources implements HomeResource
     /**
      * Get a nested list of all Home objects, including sheets, workspaces and folders, and optionally reports and/or
      * templates, as shown on the Home tab..
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /home
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -97,7 +96,7 @@ public class HomeResourcesImpl extends AbstractResources implements HomeResource
      *
      * @param includes used to specify the optional objects to include, currently TEMPLATES is supported.
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Home getHome(EnumSet<SourceInclusion> includes, EnumSet<SourceExclusion> excludes) throws SmartsheetException {

--- a/src/main/java/com/smartsheet/api/internal/ImageUrlResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/ImageUrlResourcesImpl.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,6 @@ import com.smartsheet.api.internal.http.HttpEntity;
 import com.smartsheet.api.internal.http.HttpMethod;
 import com.smartsheet.api.internal.http.HttpRequest;
 import com.smartsheet.api.internal.http.HttpResponse;
-import com.smartsheet.api.internal.json.JSONSerializerException;
 import com.smartsheet.api.internal.util.Util;
 import com.smartsheet.api.models.ImageUrl;
 import com.smartsheet.api.models.ImageUrlMap;
@@ -57,13 +56,12 @@ public class ImageUrlResourcesImpl extends AbstractResources implements ImageUrl
 
     /**
      * Gets URLS that can be used to retrieve the specified cell images.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /imageurls
      *
      * @param requestUrls array of requested Images and sizes.
      * @return the ImageUrlMap object (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
-     * @throws JSONSerializerException
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -71,8 +69,7 @@ public class ImageUrlResourcesImpl extends AbstractResources implements ImageUrl
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public ImageUrlMap getImageUrls(List<ImageUrl> requestUrls) throws SmartsheetException
-    {
+    public ImageUrlMap getImageUrls(List<ImageUrl> requestUrls) throws SmartsheetException {
         Util.throwIfNull(requestUrls);
 
         HttpRequest request;

--- a/src/main/java/com/smartsheet/api/internal/LengthEnforcingInputStream.java
+++ b/src/main/java/com/smartsheet/api/internal/LengthEnforcingInputStream.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,9 @@ public class LengthEnforcingInputStream extends FilterInputStream {
     private long expectedLength;
     private long totalBytesRead = 0L;
 
+    /**
+     * Constructor
+     */
     public LengthEnforcingInputStream(InputStream inputStream, long expectedLength) {
         super(inputStream);
         this.expectedLength = expectedLength;
@@ -54,7 +57,7 @@ public class LengthEnforcingInputStream extends FilterInputStream {
     }
 
     @Override
-    public synchronized int read (byte[] b, int off, int len) throws java.io.IOException {
+    public synchronized int read(byte[] b, int off, int len) throws java.io.IOException {
         int bytesRead = in.read(b, off, len);
         if (bytesRead == -1) {
             checkLength();
@@ -79,7 +82,6 @@ public class LengthEnforcingInputStream extends FilterInputStream {
 
     /**
      * When reset is called the total bytes read counter is set back to 0.
-     * @throws IOException
      */
     @Override
     public synchronized void reset() throws IOException {

--- a/src/main/java/com/smartsheet/api/internal/PassthroughResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/PassthroughResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,7 @@ public class PassthroughResourcesImpl extends AbstractResources implements Passt
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -102,7 +102,7 @@ public class PassthroughResourcesImpl extends AbstractResources implements Passt
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public String putRequest(String endpoint, String payload,  Map<String, Object> parameters) throws SmartsheetException {
+    public String putRequest(String endpoint, String payload, Map<String, Object> parameters) throws SmartsheetException {
         Util.throwIfNull(payload);
         return passthroughRequest(HttpMethod.PUT, endpoint, payload, parameters);
     }
@@ -131,19 +131,23 @@ public class PassthroughResourcesImpl extends AbstractResources implements Passt
      * @param payload optional JSON payload
      * @param parameters optional list of resource parameters
      * @return the result string
-     * @throws SmartsheetException
      */
-    private String passthroughRequest(HttpMethod method, String endpoint, String payload,
-                                      Map<String, Object> parameters) throws SmartsheetException {
+    private String passthroughRequest(
+            HttpMethod method,
+            String endpoint,
+            String payload,
+            Map<String, Object> parameters
+    ) throws SmartsheetException {
         Util.throwIfNull(endpoint);
         Util.throwIfEmpty(endpoint);
 
-        if(parameters != null)
+        if (parameters != null) {
             endpoint += QueryUtil.generateUrl(null, parameters);
+        }
 
         HttpRequest request = createHttpRequest(smartsheet.getBaseURI().resolve(endpoint), method);
 
-        if(payload != null) {
+        if (payload != null) {
             HttpEntity entity = new HttpEntity();
             entity.setContentType("application/json");
             entity.setContent(new ByteArrayInputStream(payload.getBytes()));
@@ -166,8 +170,7 @@ public class PassthroughResourcesImpl extends AbstractResources implements Passt
                         }
                         br.close();
                         res = sb.toString();
-                    }
-                    catch (IOException e) {
+                    } catch (IOException e) {
                         res = null;
                     }
                     break;

--- a/src/main/java/com/smartsheet/api/internal/ReportResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/ReportResourcesImpl.java
@@ -20,7 +20,6 @@ package com.smartsheet.api.internal;
  * %[license]
  */
 
-
 import com.smartsheet.api.AuthorizationException;
 import com.smartsheet.api.InvalidRequestException;
 import com.smartsheet.api.ReportResources;
@@ -45,24 +44,26 @@ import java.util.Map;
 
 /**
  * This is the implementation of the ReportResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 
-public class ReportResourcesImpl extends AbstractResources implements ReportResources{
+public class ReportResourcesImpl extends AbstractResources implements ReportResources {
 
     /**
      * Represents the ShareResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private ShareResources shares;
 
+    private static final String REPORTS_PATH = "reports/";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Parameters: - smartsheet : the SmartsheetImpl
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -74,9 +75,9 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
 
     /**
      * Get a report.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /reports/{id}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -90,18 +91,18 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @param pageSize Number of rows per page
      * @param page page number to return
      * @return  the report (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws SmartsheetException the smartsheet exception
      */
-    public Report getReport(long reportId, EnumSet<ReportInclusion> includes, Integer pageSize, Integer page) throws SmartsheetException{
+    public Report getReport(long reportId, EnumSet<ReportInclusion> includes, Integer pageSize, Integer page) throws SmartsheetException {
         return this.getReport(reportId, includes, pageSize, page, null);
     }
 
     /**
      * Get a report.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /reports/{id}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -116,11 +117,17 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @param page page number to return
      * @param level compatibility level
      * @return  the report (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws SmartsheetException the smartsheet exception
      */
-    public Report getReport(long reportId, EnumSet<ReportInclusion> includes, Integer pageSize, Integer page, Integer level) throws SmartsheetException{
-        String path = "reports/" + reportId;
+    public Report getReport(
+            long reportId,
+            EnumSet<ReportInclusion> includes,
+            Integer pageSize,
+            Integer page,
+            Integer level
+    ) throws SmartsheetException {
+        String path = REPORTS_PATH + reportId;
         Map<String, Object> parameters = new HashMap<>();
 
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
@@ -142,9 +149,9 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
 
     /**
      * Sends a report as a PDF attachment via email to the designated recipients.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /reports/{id}/emails
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -157,15 +164,15 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @param email the recipient email
      * @throws SmartsheetException the smartsheet exception
      */
-    public void sendReport(long reportId, SheetEmail email) throws SmartsheetException{
-         this.createResource("reports/" + reportId + "/emails", SheetEmail.class, email);
+    public void sendReport(long reportId, SheetEmail email) throws SmartsheetException {
+        this.createResource(REPORTS_PATH + reportId + "/emails", SheetEmail.class, email);
     }
 
     /**
      * List all reports.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /reports
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -180,8 +187,12 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
     public PagedResult<Report> listReports(PaginationParameters pagination) throws SmartsheetException {
         return this.listReports(pagination, null);
     }
+
+    /**
+     * List all reports.
+     */
     public PagedResult<Report> listReports(PaginationParameters pagination, Date modifiedSince) throws SmartsheetException {
-        String path= "reports";
+        String path = "reports";
 
         Map<String, Object> parameters = new HashMap<>();
         if (pagination != null) {
@@ -198,10 +209,10 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
 
     /**
      * Get a Report as an Excel file.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /reports/{id} with "application/vnd.ms-excel" Accept
      * HTTP header
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if outputStream is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -216,15 +227,15 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @throws SmartsheetException the smartsheet exception
      */
     public void getReportAsExcel(long id, OutputStream outputStream) throws SmartsheetException {
-        getResourceAsFile("reports/" + id, "application/vnd.ms-excel",outputStream);
+        getResourceAsFile(REPORTS_PATH + id, "application/vnd.ms-excel", outputStream);
     }
 
     /**
-     * Get a Report as an csv file.
-     *
+     * Get a Report as a csv file.
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /reports/{id} with "text/csv" Accept
      * HTTP header
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if outputStream is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -239,14 +250,14 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @throws SmartsheetException the smartsheet exception
      */
     public void getReportAsCsv(long id, OutputStream outputStream) throws SmartsheetException {
-        getResourceAsFile("reports/" + id, "text/csv",outputStream);
+        getResourceAsFile(REPORTS_PATH + id, "text/csv", outputStream);
     }
 
     /**
      * Get the publish status of a report.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /reports/{id}/publish
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -266,15 +277,15 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @throws SmartsheetException if there is any other error during the operation
      */
     public ReportPublish getPublishStatus(long id) throws SmartsheetException {
-        return this.getResource("reports/" + id + "/publish", ReportPublish.class);
+        return this.getResource(REPORTS_PATH + id + "/publish", ReportPublish.class);
     }
 
     /**
      * Sets the publish status of a report and returns the new status, including the URLs of any
      * enabled publishing.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /reports/{id}/publish
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -294,16 +305,16 @@ public class ReportResourcesImpl extends AbstractResources implements ReportReso
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public ReportPublish updatePublishStatus(long id, ReportPublish reportPublish) throws SmartsheetException{
-        return this.updateResource("reports/" + id + "/publish", ReportPublish.class, reportPublish);
+    public ReportPublish updatePublishStatus(long id, ReportPublish reportPublish) throws SmartsheetException {
+        return this.updateResource(REPORTS_PATH + id + "/publish", ReportPublish.class, reportPublish);
     }
 
-        /**
+    /**
      * <p>Creates an object of ShareResources.</p>
      *
      * @return the created ShareResources object
      */
-    public ShareResources shareResources(){
+    public ShareResources shareResources() {
         return this.shares;
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/RowAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/RowAttachmentResourcesImpl.java
@@ -35,12 +35,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+
 /**
  * This is the implementation of the RowAttachmentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class RowAttachmentResourcesImpl extends AbstractResources implements RowAttachmentResources{
+public class RowAttachmentResourcesImpl extends AbstractResources implements RowAttachmentResources {
 
     public RowAttachmentResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
@@ -48,10 +49,10 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
 
     /**
      * Attach a URL to a comment.
-     *
+     * <p>
      * The URL can be a normal URL (attachmentType "URL"), a Google Drive URL (attachmentType "GOOGLE_DRIVE") or a
      * Box.com URL (attachmentType "BOX_COM").
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/attachments
      *
      * @param sheetId the sheet id
@@ -65,19 +66,18 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Attachment attachUrl(long sheetId, long rowId, Attachment attachment) throws SmartsheetException
-    {
-        return this.createResource("sheets/" + sheetId + "/rows/" + rowId + "/attachments", Attachment.class, attachment);
+    public Attachment attachUrl(long sheetId, long rowId, Attachment attachment) throws SmartsheetException {
+        return this.createResource(createPath(sheetId, rowId), Attachment.class, attachment);
     }
 
     /**
      * Get row attachment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}/attachments
-     *
+     * <p>
      * Returns: the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
      * rather than returning null).
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -90,11 +90,11 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
      * @param rowId the row id
      * @param parameters the pagination parameters
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<Attachment> getAttachments(long sheetId, long rowId, PaginationParameters parameters) throws SmartsheetException {
-        String path= "sheets/" + sheetId + "/rows/" + rowId + "/attachments";
+        String path = createPath(sheetId, rowId);
         if (parameters != null) {
             path += parameters.toQueryString();
         }
@@ -103,7 +103,7 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
 
     /**
      * Attach a file to a row with simple upload.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/attachments
      *
      * @param sheetId the id of the sheet
@@ -138,9 +138,19 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFile(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
-            throws SmartsheetException {
+    public Attachment attachFile(
+            long sheetId,
+            long rowId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
-        return super.attachFile("sheets/" + sheetId + "/rows/" + rowId + "/attachments", inputStream, contentType, contentLength, attachmentName);
+        return super.attachFile(createPath(sheetId, rowId), inputStream, contentType, contentLength, attachmentName);
+    }
+
+    private String createPath(long sheetId, long rowId) {
+        return "sheets/" + sheetId + "/rows/" + rowId + "/attachments";
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/RowColumnResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/RowColumnResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -44,16 +45,20 @@ import java.util.Map;
 
 /**
  * This is the implementation of the RowColumnResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class RowColumnResourcesImpl extends AbstractResources implements RowColumnResources{
+public class RowColumnResourcesImpl extends AbstractResources implements RowColumnResources {
+    private static final String SHEETS_PATH = "sheets/";
+    private static final String ROWS_PATH = "/rows/";
+    private static final String COLUMNS_PATH = "/columns/";
+    private static final String CELL_IMAGES_PATH = "/cellimages";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Parameters: - smartsheet : the SmartsheetImpl
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -64,9 +69,9 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
 
     /**
      * Get the cell modification history.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/history
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -80,18 +85,23 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
      * @param sheetId the sheet Id
      * @param parameters the pagination parameters
      * @return the modification history (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<CellHistory> getCellHistory(long sheetId, long rowId, long columnId, PaginationParameters parameters) throws SmartsheetException {
-        return this.getCellHistory(sheetId, rowId, columnId, parameters, null,null);
+    public PagedResult<CellHistory> getCellHistory(
+            long sheetId,
+            long rowId,
+            long columnId,
+            PaginationParameters parameters
+    ) throws SmartsheetException {
+        return this.getCellHistory(sheetId, rowId, columnId, parameters, null, null);
     }
 
     /**
      * Get the cell modification history.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/history
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -107,12 +117,12 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
      * @param includes cell history inclusion
      * @param level compatibility level
      * @return the modification history (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *      ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<CellHistory> getCellHistory(long sheetId, long rowId, long columnId, PaginationParameters pagination,
                                                    EnumSet<CellHistoryInclusion> includes, Integer level) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/columns/"+columnId + "/history";
+        String path = SHEETS_PATH + sheetId + ROWS_PATH + rowId + COLUMNS_PATH + columnId + "/history";
 
         Map<String, Object> parameters = new HashMap<>();
         if (pagination != null) {
@@ -130,9 +140,9 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
 
     /**
      * Add an image to a cell.
-     *
+     * <p>
      * It mirrors the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/cellimages
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -149,18 +159,24 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
      * @throws SmartsheetException the smartsheet exception
      * @throws FileNotFoundException image file not found
      */
-    public void addImageToCell(long sheetId, long rowId, long columnId, String file, String contentType) throws FileNotFoundException, SmartsheetException {
+    public void addImageToCell(
+            long sheetId,
+            long rowId,
+            long columnId,
+            String file,
+            String contentType
+    ) throws FileNotFoundException, SmartsheetException {
         Util.throwIfNull(file);
         File f = new File(file);
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/columns/" + columnId + "/cellimages";
+        String path = SHEETS_PATH + sheetId + ROWS_PATH + rowId + COLUMNS_PATH + columnId + CELL_IMAGES_PATH;
         addImage(path, new FileInputStream(f), contentType, f.length(), false, null, file);
     }
 
     /**
      * Add an image to a cell.
-     *
+     * <p>
      * It mirrors the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/cellimages
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -179,19 +195,26 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
      * @throws SmartsheetException the smartsheet exception
      * @throws FileNotFoundException image file not found
      */
-    public void addImageToCell(long sheetId, long rowId, long columnId, String file, String contentType,
-                               boolean overrideValidation, String altText) throws FileNotFoundException, SmartsheetException {
+    public void addImageToCell(
+            long sheetId,
+            long rowId,
+            long columnId,
+            String file,
+            String contentType,
+            boolean overrideValidation,
+            String altText
+    ) throws FileNotFoundException, SmartsheetException {
         Util.throwIfNull(file);
         File f = new File(file);
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/columns/" + columnId + "/cellimages";
+        String path = SHEETS_PATH + sheetId + ROWS_PATH + rowId + COLUMNS_PATH + columnId + CELL_IMAGES_PATH;
         addImage(path, new FileInputStream(f), contentType, f.length(), overrideValidation, altText, file);
     }
 
     /**
      * Add an image to a cell.
-     *
+     * <p>
      * It mirrors the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/cellimages
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -213,15 +236,15 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
     public void addImageToCell(long sheetId, long rowId, long columnId, File file, String contentType,
                                boolean overrideValidation, String altText) throws FileNotFoundException, SmartsheetException {
         Util.throwIfNull(file);
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/columns/" + columnId + "/cellimages";
+        String path = SHEETS_PATH + sheetId + ROWS_PATH + rowId + COLUMNS_PATH + columnId + CELL_IMAGES_PATH;
         addImage(path, new FileInputStream(file), contentType, file.length(), overrideValidation, altText, file.getName());
     }
 
     /**
      * Add an image to a cell.
-     *
+     * <p>
      * It mirrors the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/cellimages
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -243,24 +266,24 @@ public class RowColumnResourcesImpl extends AbstractResources implements RowColu
     public void addImageToCell(long sheetId, long rowId, long columnId, InputStream inputStream, String contentType,
                                long contentLength, boolean overrideValidation, String altText) throws SmartsheetException {
         Util.throwIfNull(inputStream);
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/columns/" + columnId + "/cellimages";
+        String path = SHEETS_PATH + sheetId + ROWS_PATH + rowId + COLUMNS_PATH + columnId + CELL_IMAGES_PATH;
         addImage(path, inputStream, contentType, contentLength, overrideValidation, altText, altText);
     }
 
     private void addImage(String path, InputStream inputStream, String contentType, long contentLength,
                           boolean overrideValidation, String altText, String imageName) throws SmartsheetException {
-        if(imageName == null) {
+        if (imageName == null) {
             inputStream.toString();
         }
-        if(contentType == null) {
+        if (contentType == null) {
             contentType = "application/octet-stream";
         }
 
         Map<String, Object> parameters = new HashMap<>();
-        if(altText != null) {
+        if (altText != null) {
             parameters.put("altText", altText);
         }
-        if(overrideValidation) {
+        if (overrideValidation) {
             parameters.put("overrideValidation", "true");
         }
         path += QueryUtil.generateUrl(null, parameters);

--- a/src/main/java/com/smartsheet/api/internal/RowDiscussionResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/RowDiscussionResourcesImpl.java
@@ -16,7 +16,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
-
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -26,9 +25,9 @@ import java.util.Map;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +35,7 @@ import java.util.Map;
  * limitations under the License.
  * %[license]
  */
+
 public class RowDiscussionResourcesImpl extends AbstractResources implements RowDiscussionResources {
 
     public RowDiscussionResourcesImpl(SmartsheetImpl smartsheet) {
@@ -44,9 +44,9 @@ public class RowDiscussionResourcesImpl extends AbstractResources implements Row
 
     /**
      * Create discussion on a row.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: /sheets/{sheetId}/rows/{rowId}/discussions
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -61,15 +61,15 @@ public class RowDiscussionResourcesImpl extends AbstractResources implements Row
      * @return the created comment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Discussion createDiscussion(long sheetId, long rowId, Discussion discussion) throws SmartsheetException{
-        return this.createResource("sheets/" + sheetId + "/rows/" + rowId + "/discussions", Discussion.class, discussion);
+    public Discussion createDiscussion(long sheetId, long rowId, Discussion discussion) throws SmartsheetException {
+        return this.createResource(createPath(sheetId, rowId), Discussion.class, discussion);
     }
 
     /**
      * Create discussion on a row.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: /sheets/{sheetId}/rows/{rowId}/discussions
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -87,17 +87,32 @@ public class RowDiscussionResourcesImpl extends AbstractResources implements Row
      * @throws SmartsheetException the smartsheet exception
      * @throws IOException is there is an I/O exception
      */
-    public Discussion createDiscussionWithAttachment(long sheetId, long rowId, Discussion discussion, File file, String contentType) throws SmartsheetException, IOException{
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/discussions";
+    public Discussion createDiscussionWithAttachment(
+            long sheetId,
+            long rowId,
+            Discussion discussion,
+            File file,
+            String contentType
+    ) throws SmartsheetException, IOException {
+        String path = createPath(sheetId, rowId);
         Util.throwIfNull(sheetId, discussion, file, contentType);
 
-        return this.createResourceWithAttachment(path, Discussion.class, discussion, "discussion", new FileInputStream(file), contentType, file.getName());
+        return this.createResourceWithAttachment(
+                path,
+                Discussion.class,
+                discussion,
+                "discussion",
+                new FileInputStream(file),
+                contentType,
+                file.getName()
+        );
     }
+
     /**
      * Gets a list of all Discussions associated with the specified Row.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/rows/{rowId}/discussions
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -113,8 +128,13 @@ public class RowDiscussionResourcesImpl extends AbstractResources implements Row
      * @return the row discussions
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<Discussion> listDiscussions(long sheetId, long rowId, PaginationParameters pagination, EnumSet<DiscussionInclusion> includes) throws SmartsheetException{
-        String path = "sheets/" + sheetId + "/rows/" + rowId + "/discussions" ;
+    public PagedResult<Discussion> listDiscussions(
+            long sheetId,
+            long rowId,
+            PaginationParameters pagination,
+            EnumSet<DiscussionInclusion> includes
+    ) throws SmartsheetException {
+        String path = createPath(sheetId, rowId);
         Map<String, Object> parameters = new HashMap<>();
 
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
@@ -125,5 +145,9 @@ public class RowDiscussionResourcesImpl extends AbstractResources implements Row
         }
 
         return this.listResourcesWithWrapper(path, Discussion.class);
+    }
+
+    private String createPath(long sheetId, long rowId) {
+        return "sheets/" + sheetId + "/rows/" + rowId + "/discussions";
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SearchResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SearchResourcesImpl.java
@@ -43,14 +43,14 @@ import java.util.Map;
 
 /**
  * This is the implementation of the SearchResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class SearchResourcesImpl extends AbstractResources implements SearchResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -61,9 +61,9 @@ public class SearchResourcesImpl extends AbstractResources implements SearchReso
 
     /**
      * Performs a search across all Sheets to which user has access.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /search
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if query is null/empty string
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -74,15 +74,16 @@ public class SearchResourcesImpl extends AbstractResources implements SearchReso
      *
      * @param query the query text
      * @return the search result (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public SearchResult search(String query) throws SmartsheetException {
         return search(query, null, null, null, null);
     }
+
     /**
      * Performs a search across all Sheets to which user has access.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /search
      *
      * @param query the query text
@@ -92,7 +93,7 @@ public class SearchResourcesImpl extends AbstractResources implements SearchReso
      * @param modifiedSince only return items modified since this date
      * @param scopes enum set of search filters
      * @return the search result (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -125,9 +126,9 @@ public class SearchResourcesImpl extends AbstractResources implements SearchReso
 
     /**
      * Performs a search within a sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /search/sheet/{sheetId}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if query is null/empty string
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -140,7 +141,7 @@ public class SearchResourcesImpl extends AbstractResources implements SearchReso
      * @param sheetId the sheet id
      * @param query the query
      * @return the search result (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public SearchResult searchSheet(long sheetId, String query) throws SmartsheetException {

--- a/src/main/java/com/smartsheet/api/internal/ServerInfoResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/ServerInfoResourcesImpl.java
@@ -17,9 +17,9 @@ import com.smartsheet.api.models.ServerInfo;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,11 +27,11 @@ import com.smartsheet.api.models.ServerInfo;
  * limitations under the License.
  * %[license]
  */
-public class ServerInfoResourcesImpl extends AbstractResources implements ServerInfoResources{
+public class ServerInfoResourcesImpl extends AbstractResources implements ServerInfoResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -42,7 +42,7 @@ public class ServerInfoResourcesImpl extends AbstractResources implements Server
 
     /**
      * Gets application constants.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /serverinfo
      *
      * @return the server information
@@ -53,7 +53,7 @@ public class ServerInfoResourcesImpl extends AbstractResources implements Server
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public ServerInfo getServerInfo() throws SmartsheetException{
+    public ServerInfo getServerInfo() throws SmartsheetException {
         return this.getResource("serverinfo", ServerInfo.class);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/ShareResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/ShareResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,14 +38,15 @@ import java.util.Map;
 
 /**
  * This is the implementation of the ShareResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class ShareResourcesImpl extends AbstractAssociatedResources implements ShareResources {
+    private static final String SHARES_PATH = "/shares/";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null or empty string
      *
      * @param smartsheet the smartsheet
@@ -57,13 +58,13 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
 
     /**
      * List shares of a given object.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method:
      *     GET /workspace/{id}/shares
      *     GET /sheet/{id}/shares
      *     GET /sights/{id}/shares
      *     GET /reports/{id}/shares
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -81,7 +82,14 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
         return this.listShares(objectId, pagination, false);
     }
 
-    public PagedResult<Share> listShares(long objectId, PaginationParameters pagination, Boolean includeWorkspaceShares) throws SmartsheetException {
+    /**
+     * List shares of a given object.
+     */
+    public PagedResult<Share> listShares(
+            long objectId,
+            PaginationParameters pagination,
+            Boolean includeWorkspaceShares
+    ) throws SmartsheetException {
         String path = getMasterResourceType() + "/" + objectId + "/shares";
 
         Map<String, Object> parameters = new HashMap<>();
@@ -98,13 +106,13 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
 
     /**
      * Get a Share.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method:
      *     GET /workspaces/{workspaceId}/shares/{shareId}
      *     GET /sheets/{sheetId}/shares/{shareId}
      *     GET /sights/{sightId}/shares
      *     GET /reports/{reportId}/shares
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -116,22 +124,22 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
      * @param objectId the ID of the object to share
      * @param shareId the ID of the share
      * @return the share (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
-    public Share getShare(long objectId, String shareId) throws SmartsheetException{
-        return this.getResource(getMasterResourceType() + "/" + objectId + "/shares/" + shareId, Share.class);
+    public Share getShare(long objectId, String shareId) throws SmartsheetException {
+        return this.getResource(getMasterResourceType() + "/" + objectId + SHARES_PATH + shareId, Share.class);
     }
 
     /**
      * Shares the object with the specified Users and Groups.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method:
      *     POST /workspaces/{id}/shares
      *     POST /sheets/{id}/shares
      *     POST /sights/{id}/shares
      *     POST /reports/{reportId}/shares
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if multiShare is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -149,7 +157,7 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
      */
     public List<Share> shareTo(long objectId, List<Share> shares, Boolean sendEmail) throws SmartsheetException {
         String path = getMasterResourceType() + "/" + objectId + "/shares";
-        if (sendEmail != null){
+        if (sendEmail != null) {
             path += "?sendEmail=" + sendEmail;
         }
         return this.postAndReceiveList(path, shares, Share.class);
@@ -167,7 +175,7 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
      * @param objectId the ID of the object to share
      * @param share the share
      * @return the updated share (note that if there is no such resource, this method will throw
-     *  ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -177,18 +185,18 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
      */
     public Share updateShare(long objectId, Share share) throws SmartsheetException {
         Util.throwIfNull(share);
-        return this.updateResource(getMasterResourceType() + "/" + objectId + "/shares/" + share.getId(), Share.class, share);
+        return this.updateResource(getMasterResourceType() + "/" + objectId + SHARES_PATH + share.getId(), Share.class, share);
     }
 
     /**
      * Delete a share.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method:
      *     DELETE /workspaces/{workspaceId}/shares/{shareId}
      *     DELETE /sheets/{sheetId}/shares/{shareId}
      *     DELETE /sights/{sheetId}/shares/{shareId}
      *     DELETE /reports/{reportId}/shares/{shareId}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -202,6 +210,6 @@ public class ShareResourcesImpl extends AbstractAssociatedResources implements S
      * @throws SmartsheetException the smartsheet exception
      */
     public void deleteShare(long objectId, String shareId) throws SmartsheetException {
-        this.deleteResource(getMasterResourceType() + "/" + objectId + "/shares/" + shareId, Share.class);
+        this.deleteResource(getMasterResourceType() + "/" + objectId + SHARES_PATH + shareId, Share.class);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SheetAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetAttachmentResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,13 +36,22 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+
 /**
  * This is the implementation of the SheetAttachmentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class SheetAttachmentResourcesImpl extends AbstractResources implements SheetAttachmentResources{
+public class SheetAttachmentResourcesImpl extends AbstractResources implements SheetAttachmentResources {
     private AttachmentVersioningResources versioning;
+
+    private static final String SHEETS_PATH = "sheets/";
+
+    private static final String ATTACHMENTS_PATH = "/attachments";
+
+    /**
+     * Constructor
+     */
     public SheetAttachmentResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
         this.versioning = new AttachmentVersioningResourcesImpl(smartsheet);
@@ -49,10 +59,10 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
 
     /**
      * Attach a URL to a sheet.
-     *
+     * <p>
      * The URL can be a normal URL (attachmentType "URL"), a Google Drive URL (attachmentType "GOOGLE_DRIVE") or a
      * Box.com URL (attachmentType "BOX_COM").
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/attachments
      *
      * @param sheetId the sheet id
@@ -65,16 +75,15 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Attachment attachUrl(long sheetId, Attachment attachment) throws SmartsheetException
-    {
-        return this.createResource("sheets/" + sheetId + "/attachments", Attachment.class, attachment);
+    public Attachment attachUrl(long sheetId, Attachment attachment) throws SmartsheetException {
+        return this.createResource(SHEETS_PATH + sheetId + ATTACHMENTS_PATH, Attachment.class, attachment);
     }
 
     /**
      * Delete an attachment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/attachments/{attachmentId}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -88,17 +97,17 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
      * @throws SmartsheetException the smartsheet exception
      */
     public void deleteAttachment(long sheetId, long attachmentId) throws SmartsheetException {
-        this.deleteResource("sheets/" + sheetId + "/attachments/" + attachmentId, Attachment.class);
+        this.deleteResource(SHEETS_PATH + sheetId + "/attachments/" + attachmentId, Attachment.class);
     }
 
     /**
      * Get an attachment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /attachment/{id}
-     *
+     * <p>
      * Returns: the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
      * rather than returning null).
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -110,18 +119,18 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
      * @param sheetId the sheet id
      * @param attachmentId the attachment id
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Attachment getAttachment(long sheetId, long attachmentId) throws SmartsheetException {
-        return this.getResource("sheets/" + sheetId + "/attachments/" + attachmentId, Attachment.class);
+        return this.getResource(SHEETS_PATH + sheetId + "/attachments/" + attachmentId, Attachment.class);
     }
 
     /**
      * Gets a list of all Attachments that are on the Sheet, including Sheet, Row, and Discussion level Attachments.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/attachments
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -136,7 +145,7 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<Attachment> listAttachments(long sheetId, PaginationParameters parameters) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/attachments";
+        String path = SHEETS_PATH + sheetId + ATTACHMENTS_PATH;
 
         if (parameters != null) {
             path += parameters.toQueryString();
@@ -146,7 +155,7 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
 
     /**
      * Attach a file to a sheet with simple upload.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/attachments
      *
      * @param sheetId the id of the sheet
@@ -183,7 +192,7 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
     public Attachment attachFile(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
-        return super.attachFile("sheets/" + sheetId + "/attachments", inputStream, contentType, contentLength, attachmentName);
+        return super.attachFile(SHEETS_PATH + sheetId + ATTACHMENTS_PATH, inputStream, contentType, contentLength, attachmentName);
     }
 
     /**
@@ -192,7 +201,7 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
      * @return the created attachment
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public AttachmentVersioningResources versioningResources() throws SmartsheetException{
+    public AttachmentVersioningResources versioningResources() throws SmartsheetException {
         return versioning;
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SheetAutomationRuleResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetAutomationRuleResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,9 +33,13 @@ import java.util.Map;
 
 public class SheetAutomationRuleResourcesImpl extends AbstractResources implements SheetAutomationRuleResources {
 
+    private static final String SHEETS_PATH = "sheets/";
+
+    private static final String AUTOMATION_RULES = "automationrules";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -46,9 +50,9 @@ public class SheetAutomationRuleResourcesImpl extends AbstractResources implemen
 
     /**
      * Get all automation rules for this sheet
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/automationrules
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -63,7 +67,7 @@ public class SheetAutomationRuleResourcesImpl extends AbstractResources implemen
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<AutomationRule> listAutomationRules(long sheetId, PaginationParameters pagination) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/automationrules";
+        String path = SHEETS_PATH + sheetId + "/" + AUTOMATION_RULES;
         Map<String, Object> parameters = new HashMap<>();
 
         if (pagination != null) {
@@ -76,9 +80,9 @@ public class SheetAutomationRuleResourcesImpl extends AbstractResources implemen
 
     /**
      * Get a automation rule.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/automationrules/{automationRuleId}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -93,14 +97,14 @@ public class SheetAutomationRuleResourcesImpl extends AbstractResources implemen
      * @throws SmartsheetException the smartsheet exception
      */
     public AutomationRule getAutomationRule(long sheetId, long automationRuleId) throws SmartsheetException {
-        return this.getResource("sheets/" + sheetId + "/automationrules/" + automationRuleId, AutomationRule.class);
+        return this.getResource(SHEETS_PATH + sheetId + "/" + AUTOMATION_RULES + "/" + automationRuleId, AutomationRule.class);
     }
 
     /**
      * Updates an automation rule.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/automationrules/{automationRuleId}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -113,20 +117,20 @@ public class SheetAutomationRuleResourcesImpl extends AbstractResources implemen
      * @param sheetId the sheetId
      * @param automationRule the automation rule to update
      * @return the updated automation rule (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public AutomationRule updateAutomationRule(long sheetId, AutomationRule automationRule) throws SmartsheetException {
         Util.throwIfNull(automationRule);
-        return this.updateResource("sheets/" + sheetId + "/automationrules/" + automationRule.getId(),
+        return this.updateResource(SHEETS_PATH + sheetId + "/" + AUTOMATION_RULES + "/" + automationRule.getId(),
                 AutomationRule.class, automationRule);
     }
 
     /**
      * Delete an automation rule.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/automationrules/{automationRuleId}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -140,6 +144,6 @@ public class SheetAutomationRuleResourcesImpl extends AbstractResources implemen
      * @throws SmartsheetException the smartsheet exception
      */
     public void deleteAutomationRule(long sheetId, long automationRuleId) throws SmartsheetException {
-        this.deleteResource("sheets/" + sheetId + "/automationrules/" + automationRuleId, AutomationRule.class);
+        this.deleteResource(SHEETS_PATH + sheetId + "/" + AUTOMATION_RULES + "/" + automationRuleId, AutomationRule.class);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SheetColumnResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetColumnResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,14 +40,17 @@ import java.util.Map;
 
 /**
  * This is the implementation of the SheetColumnResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class SheetColumnResourcesImpl extends AbstractResources implements SheetColumnResources {
 
+    private static final String SHEETS_PATH = "sheets/";
+    private static final String COLUMNS = "columns";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -58,9 +61,9 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
 
     /**
      * List columns of a given sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/columns
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -75,15 +78,19 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
      * @return the columns (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<Column> listColumns(long sheetId, EnumSet<ColumnInclusion> includes, PaginationParameters pagination) throws SmartsheetException  {
+    public PagedResult<Column> listColumns(
+            long sheetId,
+            EnumSet<ColumnInclusion> includes,
+            PaginationParameters pagination
+    ) throws SmartsheetException {
         return this.listColumns(sheetId, includes, pagination, null);
     }
 
     /**
      * List columns of a given sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/columns
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -99,8 +106,13 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
      * @return the columns (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<Column> listColumns(long sheetId, EnumSet<ColumnInclusion> includes, PaginationParameters pagination, Integer level) throws SmartsheetException  {
-        String path = "sheets/" + sheetId + "/columns";
+    public PagedResult<Column> listColumns(
+            long sheetId,
+            EnumSet<ColumnInclusion> includes,
+            PaginationParameters pagination,
+            Integer level
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/" + COLUMNS;
 
         Map<String, Object> parameters = new HashMap<>();
         if (pagination != null) {
@@ -116,9 +128,9 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
 
     /**
      * Add column to a sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/columns
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -130,18 +142,18 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
      *
      * @param sheetId the sheet id
      * @param columns the list of columns object limited to the following attributes: *
-     * title * type * symbol (optional) * options (optional) - array of options * index (zero-based) * systemColumnType
-     * (optional) * autoNumberFormat (optional)
+     *     title * type * symbol (optional) * options (optional) - array of options * index (zero-based) * systemColumnType
+     *     (optional) * autoNumberFormat (optional)
      * @return the list of created columns
      * @throws SmartsheetException the smartsheet exception
      */
     public List<Column> addColumns(long sheetId, List<Column> columns) throws SmartsheetException {
-        return this.postAndReceiveList("sheets/" + sheetId + "/columns", columns, Column.class);
+        return this.postAndReceiveList(SHEETS_PATH + sheetId + "/" + COLUMNS, columns, Column.class);
     }
 
     /**
      * Delete column.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/columns/{columnId}
      *
      * @param sheetId the sheet id
@@ -155,14 +167,14 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void deleteColumn(long sheetId, long columnId) throws SmartsheetException {
-        this.deleteResource("sheets/" + sheetId + "/columns/" + columnId, Column.class);
+        this.deleteResource(SHEETS_PATH + sheetId + "/" + COLUMNS + "/" + columnId, Column.class);
     }
 
     /**
      * Update a column.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/columns/{columnId}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -174,22 +186,22 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
      *
      * @param sheetId the sheetId
      * @param column the column to update limited to the following attributes: index (column's new index in the sheet),
-     * title, sheetId, type, options (optional), symbol (optional), systemColumnType (optional),
-     * autoNumberFormat (optional)
+     *     title, sheetId, type, options (optional), symbol (optional), systemColumnType (optional),
+     *     autoNumberFormat (optional)
      * @return the updated sheet (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Column updateColumn(long sheetId, Column column) throws SmartsheetException {
         Util.throwIfNull(column);
-        return this.updateResource("sheets/" + sheetId + "/columns/" + column.getId(), Column.class, column);
+        return this.updateResource(SHEETS_PATH + sheetId + "/" + COLUMNS + "/" + column.getId(), Column.class, column);
     }
 
     /**
      * Gets the Column specified in the URL.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/columns/{columnId}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -204,8 +216,8 @@ public class SheetColumnResourcesImpl extends AbstractResources implements Sheet
      * @return the column (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
-    public Column getColumn(long sheetId, long columnId, EnumSet<ColumnInclusion> includes) throws SmartsheetException  {
-        String path = "sheets/" + sheetId + "/columns/" + columnId;
+    public Column getColumn(long sheetId, long columnId, EnumSet<ColumnInclusion> includes) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/" + COLUMNS + "/" + columnId;
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));

--- a/src/main/java/com/smartsheet/api/internal/SheetCommentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetCommentResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,17 +23,19 @@ package com.smartsheet.api.internal;
 import com.smartsheet.api.SheetCommentResources;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.Comment;
+
 /**
  * This is the implementation of the SheetCommentResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
-public class SheetCommentResourcesImpl extends AbstractResources implements SheetCommentResources{
+public class SheetCommentResourcesImpl extends AbstractResources implements SheetCommentResources {
 
     private com.smartsheet.api.CommentAttachmentResources attachments;
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -44,9 +47,9 @@ public class SheetCommentResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Get a comment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /comment/{id}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -58,7 +61,7 @@ public class SheetCommentResourcesImpl extends AbstractResources implements Shee
      * @param sheetId the ID of the sheet
      * @param commentId the ID of the comment
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws SmartsheetException the smartsheet exception
      */
     public Comment getComment(long sheetId, long commentId) throws SmartsheetException {
@@ -67,9 +70,9 @@ public class SheetCommentResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Delete a comment.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /comment{id}
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -92,7 +95,7 @@ public class SheetCommentResourcesImpl extends AbstractResources implements Shee
      * @return the created attachment
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public com.smartsheet.api.CommentAttachmentResources attachmentResources() throws SmartsheetException{
+    public com.smartsheet.api.CommentAttachmentResources attachmentResources() throws SmartsheetException {
         return attachments;
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SheetCrossSheetReferenceResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetCrossSheetReferenceResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,10 +35,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SheetCrossSheetReferenceResourcesImpl extends AbstractResources implements SheetCrossSheetReferenceResources {
+    private static final String SHEETS_PATH = "sheets/";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -65,9 +66,11 @@ public class SheetCrossSheetReferenceResourcesImpl extends AbstractResources imp
      * @return a list of cross sheet references
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<CrossSheetReference> listCrossSheetReferences(long sheetId, PaginationParameters pagination) throws SmartsheetException
-    {
-        String path = "sheets/" + sheetId + "/crosssheetreferences";
+    public PagedResult<CrossSheetReference> listCrossSheetReferences(
+            long sheetId,
+            PaginationParameters pagination
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/crosssheetreferences";
         Map<String, Object> parameters = new HashMap<>();
 
         if (pagination != null) {
@@ -86,7 +89,7 @@ public class SheetCrossSheetReferenceResourcesImpl extends AbstractResources imp
      * @param sheetId the sheet id
      * @param crossSheetReferenceId the cross sheet reference id
      * @return the cross sheet reference (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -94,9 +97,8 @@ public class SheetCrossSheetReferenceResourcesImpl extends AbstractResources imp
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public CrossSheetReference getCrossSheetReference(long sheetId, long crossSheetReferenceId) throws SmartsheetException
-    {
-        return this.getResource("sheets/" + sheetId + "/crosssheetreferences/" + crossSheetReferenceId, CrossSheetReference.class);
+    public CrossSheetReference getCrossSheetReference(long sheetId, long crossSheetReferenceId) throws SmartsheetException {
+        return this.getResource(SHEETS_PATH + sheetId + "/crosssheetreferences/" + crossSheetReferenceId, CrossSheetReference.class);
     }
 
     /**
@@ -114,8 +116,7 @@ public class SheetCrossSheetReferenceResourcesImpl extends AbstractResources imp
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public CrossSheetReference createCrossSheetReference(long sheetId, CrossSheetReference crossSheetReference) throws SmartsheetException
-    {
-        return this.createResource("sheets/" + sheetId + "/crosssheetreferences", CrossSheetReference.class, crossSheetReference);
+    public CrossSheetReference createCrossSheetReference(long sheetId, CrossSheetReference crossSheetReference) throws SmartsheetException {
+        return this.createResource(SHEETS_PATH + sheetId + "/crosssheetreferences", CrossSheetReference.class, crossSheetReference);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SheetDiscussionResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetDiscussionResourcesImpl.java
@@ -32,9 +32,9 @@ import java.util.Map;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,13 +42,17 @@ import java.util.Map;
  * limitations under the License.
  * %[license]
  */
-public class SheetDiscussionResourcesImpl extends  AbstractResources implements SheetDiscussionResources {
+
+public class SheetDiscussionResourcesImpl extends AbstractResources implements SheetDiscussionResources {
     DiscussionAttachmentResources attachments;
     DiscussionCommentResources comments;
 
+    private static final String SHEETS_PATH = "sheets/";
+    private static final String DISCUSSIONS = "discussions";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null or empty string
      *
@@ -62,7 +66,7 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
 
     /**
      * Create a discussion on a sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/discussions
      *
      * @param sheetId the sheet id
@@ -75,15 +79,15 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Discussion createDiscussion(long sheetId, Discussion discussion) throws SmartsheetException{
+    public Discussion createDiscussion(long sheetId, Discussion discussion) throws SmartsheetException {
         Util.throwIfNull(sheetId, discussion);
-        return this.createResource("sheets/" + sheetId + "/discussions",
+        return this.createResource(SHEETS_PATH + sheetId + "/" + DISCUSSIONS,
                 Discussion.class, discussion);
     }
 
     /**
      * Create a discussion with attachments on a sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/discussions
      *
      * @param sheetId the sheet id
@@ -99,27 +103,45 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @throws SmartsheetException if there is any other error during the operation
      * @throws IOException is there is with file
      */
-    public Discussion createDiscussionWithAttachment(long sheetId, Discussion discussion, File file, String contentType) throws SmartsheetException, IOException{
+    public Discussion createDiscussionWithAttachment(
+            long sheetId,
+            Discussion discussion,
+            File file,
+            String contentType
+    ) throws SmartsheetException, IOException {
         Util.throwIfNull(discussion, file, contentType);
-        String path = "sheets/" + sheetId + "/discussions";
+        String path = SHEETS_PATH + sheetId + "/" + DISCUSSIONS;
 
         return this.createDiscussionWithAttachment(path, discussion, new FileInputStream(file), contentType, file.getName());
     }
 
-    private Discussion createDiscussionWithAttachment(String path, Discussion discussion, InputStream inputStream, String contentType, String attachmentName) throws SmartsheetException{
-        return this.createResourceWithAttachment(path, Discussion.class, discussion, "discussion", inputStream, contentType, attachmentName);
+    private Discussion createDiscussionWithAttachment(
+            String path, Discussion discussion,
+            InputStream inputStream,
+            String contentType,
+            String attachmentName
+    ) throws SmartsheetException {
+        return this.createResourceWithAttachment(
+                path,
+                Discussion.class,
+                discussion,
+                "discussion",
+                inputStream,
+                contentType,
+                attachmentName
+        );
     }
 
     /**
      * Get a discussion.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/discussions/{discussionId}
-     *
+     * <p>
      * Parameters: - discussionId : the ID
-     *
+     * <p>
      * Returns: the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
      * rather than returning null).
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -134,14 +156,14 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @throws SmartsheetException the smartsheet exception
      */
     public Discussion getDiscussion(long sheetId, long discussionId) throws SmartsheetException {
-        return this.getResource("sheets/" + sheetId + "/discussions/" + discussionId, Discussion.class);
+        return this.getResource(SHEETS_PATH + sheetId + "/" + DISCUSSIONS + "/" + discussionId, Discussion.class);
     }
 
     /**
      * Delete discussion.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/discussions/{discussionId}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -154,15 +176,15 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @param discussionId the discussion ID
      * @throws SmartsheetException the smartsheet exception
      */
-    public void deleteDiscussion(long sheetId, long discussionId) throws SmartsheetException{
-        this.deleteResource("sheets/" + sheetId + "/discussions/" + discussionId, Discussion.class);
+    public void deleteDiscussion(long sheetId, long discussionId) throws SmartsheetException {
+        this.deleteResource(SHEETS_PATH + sheetId + "/" + DISCUSSIONS + "/" + discussionId, Discussion.class);
     }
 
     /**
      * Get all discussions.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/discussions
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -177,8 +199,12 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @return all the discussions
      * @throws SmartsheetException the smartsheet exception
      */
-    public PagedResult<Discussion> listDiscussions(long sheetId, PaginationParameters pagination, EnumSet<DiscussionInclusion> includes) throws SmartsheetException{
-        String path = "sheets/" + sheetId + "/discussions";
+    public PagedResult<Discussion> listDiscussions(
+            long sheetId,
+            PaginationParameters pagination,
+            EnumSet<DiscussionInclusion> includes
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/" + DISCUSSIONS;
         Map<String, Object> parameters = new HashMap<>();
 
         if (pagination != null) {
@@ -196,7 +222,7 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @return the created DiscussionCommentResources object
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public DiscussionCommentResources commentResources() throws SmartsheetException{
+    public DiscussionCommentResources commentResources() throws SmartsheetException {
         return this.comments;
     }
 
@@ -206,7 +232,7 @@ public class SheetDiscussionResourcesImpl extends  AbstractResources implements 
      * @return the created DiscussionAttachmentResources object
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public DiscussionAttachmentResources attachmentResources() throws SmartsheetException{
+    public DiscussionAttachmentResources attachmentResources() throws SmartsheetException {
         return this.attachments;
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SheetFilterResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetFilterResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,11 +30,12 @@ import com.smartsheet.api.models.SheetFilter;
 import java.util.HashMap;
 import java.util.Map;
 
-public class SheetFilterResourcesImpl extends  AbstractResources implements SheetFilterResources {
+public class SheetFilterResourcesImpl extends AbstractResources implements SheetFilterResources {
+    private static final String SHEETS_PATH = "sheets/";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null or empty string
      *
@@ -46,14 +47,14 @@ public class SheetFilterResourcesImpl extends  AbstractResources implements Shee
 
     /**
      * Get a filter.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/filters/{filterId}
-     *
+     * <p>
      * Parameters: - filterId : the ID
-     *
+     * <p>
      * Returns: the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
      * rather than returning null).
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -68,14 +69,14 @@ public class SheetFilterResourcesImpl extends  AbstractResources implements Shee
      * @throws SmartsheetException the smartsheet exception
      */
     public SheetFilter getFilter(long sheetId, long filterId) throws SmartsheetException {
-        return this.getResource("sheets/" + sheetId + "/filters/" + filterId, SheetFilter.class);
+        return this.getResource(SHEETS_PATH + sheetId + "/filters/" + filterId, SheetFilter.class);
     }
 
     /**
      * Delete filter.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/filters/{filterId}
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -89,14 +90,14 @@ public class SheetFilterResourcesImpl extends  AbstractResources implements Shee
      * @throws SmartsheetException the smartsheet exception
      */
     public void deleteFilter(long sheetId, long filterId) throws SmartsheetException {
-        this.deleteResource("sheets/" + sheetId + "/filters/" + filterId, SheetFilter.class);
+        this.deleteResource(SHEETS_PATH + sheetId + "/filters/" + filterId, SheetFilter.class);
     }
 
     /**
      * Get all filters.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/filters
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if any argument is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -111,7 +112,7 @@ public class SheetFilterResourcesImpl extends  AbstractResources implements Shee
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<SheetFilter> listFilters(long sheetId, PaginationParameters pagination) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/filters";
+        String path = SHEETS_PATH + sheetId + "/filters";
         Map<String, Object> parameters = new HashMap<>();
 
         if (pagination != null) {

--- a/src/main/java/com/smartsheet/api/internal/SheetResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetResourcesImpl.java
@@ -78,7 +78,7 @@ import java.util.Set;
 
 /**
  * This is the implementation of the SheetResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class SheetResourcesImpl extends AbstractResources implements SheetResources {
@@ -86,76 +86,84 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
     /** The Constant BUFFER_SIZE. */
     private static final int BUFFER_SIZE = 4098;
 
+    private static final String SHEETS = "sheets";
+    private static final String TEXT_CSV = "text/csv";
+    private static final String FOLDERS = "folders";
+    private static final String INCLUDE = "include";
+    private static final String IMPORT = "import";
+    private static final String WORKSPACES = "WORKSPACES";
+    private static final String XLSX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
     /**
      * Represents the ShareResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private ShareResources shares;
     /**
      * Represents the SheetRowResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private SheetRowResources rows;
     /**
      * Represents the SheetColumnResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private SheetColumnResources columns;
     /**
      * Represents the AssociatedAttachmentResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private SheetAttachmentResources attachments;
     /**
      * Represents the AssociatedDiscussionResources.
-     *
-     * It will be initialized in constructor and will not change afterwards.
+     * <p>
+     * It will be initialized in constructor and will not change afterward.
      */
     private SheetDiscussionResources discussions;
 
     /**
      * Represents the SheetCommentResources.
-     *
-     * It will be initialized in constructor and will not change afterwards
+     * <p>
+     * It will be initialized in constructor and will not change afterward
      */
     private SheetCommentResources comments;
 
     /**
      * Represents the SheetUpdateRequestResources.
-     *
-     * It will be initialized in constructor and will not change afterwards
+     * <p>
+     * It will be initialized in constructor and will not change afterward
      */
     private SheetUpdateRequestResources updateRequests;
 
     /**
      * Represents the SheetFilterResources.
-     *
-     * It will be initialized in constructor and will not change afterwards
+     * <p>
+     * It will be initialized in constructor and will not change afterward
      */
     private SheetFilterResources filters;
 
     /**
      * Represents the AutomationRules.
-     *
-     * It will be initialized in the constructor and will not change afterwards
+     * <p>
+     * It will be initialized in the constructor and will not change afterward
      */
     private SheetAutomationRuleResources automationRules;
 
     /**
      * Represents the CrossSheetReferences
-     *
-     * It will be initialized in the constructor and will not change afterwards
+     * <p>
+     * It will be initialized in the constructor and will not change afterward
      */
     private SheetCrossSheetReferenceResources crossSheetReferences;
 
     /**
      * Represents the sheetSummary
-     *
-     * It will be initialized in the constructor and will not change afterwards
+     * <p>
+     * It will be initialized in the constructor and will not change afterward
      */
     private SheetSummaryResources sheetSummary;
 
@@ -166,7 +174,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      */
     public SheetResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
-        this.shares = new ShareResourcesImpl(smartsheet, "sheets");
+        this.shares = new ShareResourcesImpl(smartsheet, SHEETS);
         this.rows = new SheetRowResourcesImpl(smartsheet);
         this.columns = new SheetColumnResourcesImpl(smartsheet);
         this.attachments = new SheetAttachmentResourcesImpl(smartsheet);
@@ -197,12 +205,15 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
         return this.listSheets(includes, pagination, null);
     }
 
+    /**
+     * List Sheets
+     */
     public PagedResult<Sheet> listSheets(
             EnumSet<SourceInclusion> includes,
             PaginationParameters pagination,
             Date modifiedSince
     ) throws SmartsheetException {
-        String path = "sheets";
+        String path = SHEETS;
 
         Map<String, Object> parameters = new HashMap<>();
         if (pagination != null) {
@@ -212,7 +223,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             String isoDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(modifiedSince);
             parameters.put("modifiedSince", isoDate);
         }
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
 
         path += QueryUtil.generateUrl(null, parameters);
         return this.listResourcesWithWrapper(path, Sheet.class);
@@ -346,12 +357,12 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             Integer level
     ) throws SmartsheetException {
 
-        String path = "sheets/" + id;
+        String path = SHEETS + "/" + id;
 
         // Add the parameters to a map and build the query string at the end
         Map<String, Object> parameters = new HashMap<>();
 
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
         parameters.put("exclude", QueryUtil.generateCommaSeparatedList(excludes));
         parameters.put("rowIds", QueryUtil.generateCommaSeparatedList(rowIds));
         parameters.put("rowNumbers", QueryUtil.generateCommaSeparatedList(rowNumbers));
@@ -422,7 +433,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public Sheet createSheet(Sheet sheet) throws SmartsheetException {
-        return this.createResource("sheets", Sheet.class, sheet);
+        return this.createResource(SHEETS, Sheet.class, sheet);
     }
 
     /**
@@ -442,8 +453,8 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      */
     public Sheet createSheetFromTemplate(Sheet sheet, EnumSet<SheetTemplateInclusion> includes) throws SmartsheetException {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        String path = QueryUtil.generateUrl("sheets", parameters);
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        String path = QueryUtil.generateUrl(SHEETS, parameters);
 
         return this.createResource(path, Sheet.class, sheet);
     }
@@ -465,7 +476,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Sheet importCsv(String file, String sheetName, Integer headerRowIndex, Integer primaryColumnIndex) throws SmartsheetException {
-        return importFile("sheets/import", file, "text/csv", sheetName, headerRowIndex, primaryColumnIndex);
+        return importFile("sheets/import", file, TEXT_CSV, sheetName, headerRowIndex, primaryColumnIndex);
     }
 
     /**
@@ -485,7 +496,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Sheet importXlsx(String file, String sheetName, Integer headerRowIndex, Integer primaryColumnIndex) throws SmartsheetException {
-        return importFile("sheets/import", file, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        return importFile("sheets/import", file, XLSX_CONTENT_TYPE,
                 sheetName, headerRowIndex, primaryColumnIndex);
     }
 
@@ -507,7 +518,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      */
     public Sheet createSheetInFolder(long folderId, Sheet sheet) throws SmartsheetException {
 
-        return this.createResource("folders/" + folderId + "/sheets", Sheet.class, sheet);
+        return this.createResource(FOLDERS + "/" + folderId + "/" + SHEETS, Sheet.class, sheet);
     }
 
     /**
@@ -533,8 +544,8 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             EnumSet<SheetTemplateInclusion> includes
     ) throws SmartsheetException {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        String path = QueryUtil.generateUrl("folders/" + folderId + "/sheets", parameters);
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        String path = QueryUtil.generateUrl(FOLDERS + "/" + folderId + "/" + SHEETS, parameters);
 
         return this.createResource(path, Sheet.class, sheet);
     }
@@ -563,8 +574,14 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             Integer headerRowIndex,
             Integer primaryColumnIndex
     ) throws SmartsheetException {
-        return importFile("folders/" + folderId + "/sheets/import", file, "text/csv",
-                sheetName, headerRowIndex, primaryColumnIndex);
+        return importFile(
+                FOLDERS + "/" + folderId + "/" + SHEETS + "/" + IMPORT,
+                file,
+                TEXT_CSV,
+                sheetName,
+                headerRowIndex,
+                primaryColumnIndex
+        );
     }
 
     /**
@@ -591,9 +608,14 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             Integer headerRowIndex,
             Integer primaryColumnIndex
     ) throws SmartsheetException {
-        return importFile("folders/" + folderId + "/sheets/import", file,
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", sheetName,
-                headerRowIndex, primaryColumnIndex);
+        return importFile(
+                FOLDERS + "/" + folderId + "/" + SHEETS + "/" + IMPORT,
+                file,
+                XLSX_CONTENT_TYPE,
+                sheetName,
+                headerRowIndex,
+                primaryColumnIndex
+        );
     }
 
     /**
@@ -612,7 +634,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public Sheet createSheetInWorkspace(long workspaceId, Sheet sheet) throws SmartsheetException {
-        return this.createResource("workspaces/" + workspaceId + "/sheets", Sheet.class, sheet);
+        return this.createResource(WORKSPACES + "/" + workspaceId + "/" + SHEETS, Sheet.class, sheet);
     }
 
     /**
@@ -635,8 +657,8 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
     public Sheet createSheetInWorkspaceFromTemplate(long workspaceId, Sheet sheet, EnumSet<SheetTemplateInclusion> includes)
             throws SmartsheetException {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        String path = QueryUtil.generateUrl("workspaces/" + workspaceId + "/sheets", parameters);
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        String path = QueryUtil.generateUrl(WORKSPACES + "/" + workspaceId + "/" + SHEETS, parameters);
 
         return this.createResource(path, Sheet.class, sheet);
     }
@@ -665,8 +687,14 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             Integer headerRowIndex,
             Integer primaryColumnIndex
     ) throws SmartsheetException {
-        return importFile("workspaces/" + workspaceId + "/sheets/import", file,
-                "text/csv", sheetName, headerRowIndex, primaryColumnIndex);
+        return importFile(
+                WORKSPACES + "/" + workspaceId + "/" + SHEETS + "/" + IMPORT,
+                file,
+                TEXT_CSV,
+                sheetName,
+                headerRowIndex,
+                primaryColumnIndex
+        );
     }
 
     /**
@@ -693,9 +721,14 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             Integer headerRowIndex,
             Integer primaryColumnIndex
     ) throws SmartsheetException {
-        return importFile("workspaces/" + workspaceId + "/sheets/import", file,
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", sheetName,
-                headerRowIndex, primaryColumnIndex);
+        return importFile(
+                WORKSPACES + "/" + workspaceId + "/" + SHEETS + "/" + IMPORT,
+                file,
+                XLSX_CONTENT_TYPE,
+                sheetName,
+                headerRowIndex,
+                primaryColumnIndex
+        );
     }
 
     /**
@@ -711,7 +744,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public void deleteSheet(long id) throws SmartsheetException {
-        this.deleteResource("sheets/" + id, Sheet.class);
+        this.deleteResource(SHEETS + "/" + id, Sheet.class);
     }
 
     /**
@@ -728,7 +761,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Sheet updateSheet(Sheet sheet) throws SmartsheetException {
-        return this.updateResource("sheets/" + sheet.getId(), Sheet.class, sheet);
+        return this.updateResource(SHEETS + "/" + sheet.getId(), Sheet.class, sheet);
     }
 
     /**
@@ -746,7 +779,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public int getSheetVersion(long id) throws SmartsheetException {
-        return this.getResource("sheets/" + id + "/version", Sheet.class).getVersion();
+        return this.getResource(SHEETS + "/" + id + "/version", Sheet.class).getVersion();
     }
 
     /**
@@ -763,7 +796,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public void sendSheet(long id, SheetEmail email) throws SmartsheetException {
-        this.createResource("sheets/" + id + "/emails", SheetEmail.class, email);
+        this.createResource(SHEETS + "/" + id + "/emails", SheetEmail.class, email);
     }
 
     /**
@@ -780,7 +813,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void getSheetAsCSV(long id, OutputStream outputStream) throws SmartsheetException {
-        getSheetAsFile(id, null, outputStream, "text/csv");
+        getSheetAsFile(id, null, outputStream, TEXT_CSV);
     }
 
     /**
@@ -798,7 +831,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public SheetPublish getPublishStatus(long id) throws SmartsheetException {
-        return this.getResource("sheets/" + id + "/publish", SheetPublish.class);
+        return this.getResource(SHEETS + "/" + id + "/publish", SheetPublish.class);
     }
 
     /**
@@ -819,7 +852,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public SheetPublish updatePublishStatus(long id, SheetPublish publish) throws SmartsheetException {
-        return this.updateResource("sheets/" + id + "/publish", SheetPublish.class, publish);
+        return this.updateResource(SHEETS + "/" + id + "/publish", SheetPublish.class, publish);
     }
 
     /**
@@ -868,10 +901,10 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             EnumSet<CopyExclusion> excludes
     ) throws SmartsheetException {
 
-        String path = "sheets/" + sheetId + "/copy";
+        String path = SHEETS + "/" + sheetId + "/copy";
         Map<String, Object> parameters = new HashMap<>();
 
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
         parameters.put("exclude", QueryUtil.generateCommaSeparatedList(excludes));
 
         path += QueryUtil.generateUrl(null, parameters);
@@ -895,7 +928,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      */
     public Sheet moveSheet(long sheetId, ContainerDestination containerDestination) throws SmartsheetException {
 
-        String path = "sheets/" + sheetId + "/move";
+        String path = SHEETS + "/" + sheetId + "/move";
         return this.createResource(path, Sheet.class, containerDestination);
     }
 
@@ -914,7 +947,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public UpdateRequest createUpdateRequest(long sheetId, MultiRowEmail email) throws SmartsheetException {
-        return this.createResource("sheets/" + sheetId + "/updaterequests", UpdateRequest.class, email);
+        return this.createResource(SHEETS + "/" + sheetId + "/updaterequests", UpdateRequest.class, email);
     }
 
     /**
@@ -954,7 +987,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
     public Sheet sortSheet(long sheetId, SortSpecifier sortSpecifier, Integer level) throws SmartsheetException {
         Util.throwIfNull(sortSpecifier);
 
-        String path = "sheets/" + sheetId + "/sort";
+        String path = SHEETS + "/" + sheetId + "/sort";
         if (level != null) {
             path += "?level=" + level;
         }
@@ -1182,7 +1215,7 @@ public class SheetResourcesImpl extends AbstractResources implements SheetResour
             throws SmartsheetException {
         Util.throwIfNull(outputStream, contentType);
 
-        String path = "sheets/" + id;
+        String path = SHEETS + "/" + id;
         if (paperSize != null) {
             path += "?paperSize=" + paperSize;
         }

--- a/src/main/java/com/smartsheet/api/internal/SheetRowResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetRowResourcesImpl.java
@@ -62,13 +62,19 @@ import java.util.Set;
 
 /**
  * This is the implementation of the SheetRowResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class SheetRowResourcesImpl extends AbstractResources implements SheetRowResources {
     RowAttachmentResources attachments;
     RowDiscussionResources discussions;
     RowColumnResources columns;
+
+    private static final String IGNORE_ROWS_NOT_FOUND = "ignoreRowsNotFound";
+    private static final String SHEETS_PATH = "sheets/";
+    private static final String ROWS = "rows";
+    private static final String INCLUDE = "include";
+    private static final String EXCLUDE = "exclude";
 
     /**
      * Constructor.
@@ -124,12 +130,12 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
             EnumSet<RowInclusion> includes,
             EnumSet<ObjectExclusion> excludes
     ) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/rows";
+        String path = SHEETS_PATH + sheetId + "/" + ROWS;
 
         Map<String, Object> parameters = new HashMap<>();
 
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        parameters.put("exclude", QueryUtil.generateCommaSeparatedList(excludes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(EXCLUDE, QueryUtil.generateCommaSeparatedList(excludes));
 
         path += QueryUtil.generateUrl(null, parameters);
         return this.postAndReceiveList(path, rows, Row.class);
@@ -203,12 +209,12 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
             EnumSet<RowInclusion> includes,
             EnumSet<ObjectExclusion> excludes
     ) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/rows/" + rowId;
+        String path = SHEETS_PATH + sheetId + "/" + ROWS + "/" + rowId;
 
         Map<String, Object> parameters = new HashMap<>();
 
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        parameters.put("exclude", QueryUtil.generateCommaSeparatedList(excludes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(EXCLUDE, QueryUtil.generateCommaSeparatedList(excludes));
 
         path += QueryUtil.generateUrl(null, parameters);
         return this.getResource(path, Row.class);
@@ -230,7 +236,7 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
      */
     @Deprecated
     public void deleteRow(long sheetId, long rowId) throws SmartsheetException {
-        this.deleteResource("sheets/" + sheetId + "/rows/" + rowId, Row.class);
+        this.deleteResource(SHEETS_PATH + sheetId + "/" + ROWS + "/" + rowId, Row.class);
     }
 
     /**
@@ -251,9 +257,9 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
     public List<Long> deleteRows(long sheetId, Set<Long> rowIds, boolean ignoreRowsNotFound) throws SmartsheetException {
         Util.throwIfNull(rowIds);
         Map<String, Object> parameters = new HashMap<>();
-        String path = "sheets/" + sheetId + "/rows/";
+        String path = SHEETS_PATH + sheetId + "/" + ROWS + "/";
         parameters.put("ids", QueryUtil.generateCommaSeparatedList(rowIds));
-        parameters.put("ignoreRowsNotFound", ignoreRowsNotFound);
+        parameters.put(IGNORE_ROWS_NOT_FOUND, ignoreRowsNotFound);
 
         path += QueryUtil.generateUrl(null, parameters);
 
@@ -277,7 +283,7 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
      */
     @Deprecated
     public void sendRow(long sheetId, long rowId, RowEmail email) throws SmartsheetException {
-        this.createResource("sheets/" + sheetId + "/rows/" + rowId + "/emails", RowEmail.class, email);
+        this.createResource(SHEETS_PATH + sheetId + "/" + ROWS + "/" + rowId + "/emails", RowEmail.class, email);
     }
 
     /**
@@ -294,7 +300,7 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
      * @throws SmartsheetException : if there is any other error occurred during the operation
      */
     public void sendRows(long sheetId, MultiRowEmail email) throws SmartsheetException {
-        this.createResource("sheets/" + sheetId + "/rows/emails", MultiRowEmail.class, email);
+        this.createResource(SHEETS_PATH + sheetId + "/rows/emails", MultiRowEmail.class, email);
     }
 
     /**
@@ -337,12 +343,12 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
             EnumSet<RowInclusion> includes,
             EnumSet<ObjectExclusion> excludes
     ) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/rows";
+        String path = SHEETS_PATH + sheetId + "/" + ROWS;
 
         Map<String, Object> parameters = new HashMap<>();
 
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        parameters.put("exclude", QueryUtil.generateCommaSeparatedList(excludes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(EXCLUDE, QueryUtil.generateCommaSeparatedList(excludes));
 
         path += QueryUtil.generateUrl(null, parameters);
         return this.putAndReceiveList(path, rows, Row.class);
@@ -407,11 +413,11 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
             throw new IllegalArgumentException();
         }
 
-        String path = "sheets/" + sheetId + "/rows";
+        String path = SHEETS_PATH + sheetId + "/" + ROWS;
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("allowPartialSuccess", "true");
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        parameters.put("exclude", QueryUtil.generateCommaSeparatedList(excludes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(EXCLUDE, QueryUtil.generateCommaSeparatedList(excludes));
 
         path = QueryUtil.generateUrl(path, parameters);
 
@@ -484,12 +490,12 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
             Boolean ignoreRowsNotFound,
             CopyOrMoveRowDirective moveParameters
     ) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/rows/move";
+        String path = SHEETS_PATH + sheetId + "/rows/move";
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
 
         if (ignoreRowsNotFound != null) {
-            parameters.put("ignoreRowsNotFound", ignoreRowsNotFound.toString());
+            parameters.put(IGNORE_ROWS_NOT_FOUND, ignoreRowsNotFound.toString());
         }
 
         path += QueryUtil.generateUrl(null, parameters);
@@ -518,12 +524,12 @@ public class SheetRowResourcesImpl extends AbstractResources implements SheetRow
             Boolean ignoreRowsNotFound,
             CopyOrMoveRowDirective copyParameters
     ) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/rows/copy";
+        String path = SHEETS_PATH + sheetId + "/rows/copy";
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
+        parameters.put(INCLUDE, QueryUtil.generateCommaSeparatedList(includes));
 
         if (ignoreRowsNotFound != null) {
-            parameters.put("ignoreRowsNotFound", ignoreRowsNotFound.toString());
+            parameters.put(IGNORE_ROWS_NOT_FOUND, ignoreRowsNotFound.toString());
         }
 
         path += QueryUtil.generateUrl(null, parameters);

--- a/src/main/java/com/smartsheet/api/internal/SheetSummaryResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetSummaryResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.AuthorizationException;
 import com.smartsheet.api.InvalidRequestException;
@@ -57,10 +56,16 @@ import java.util.Map;
 import java.util.Set;
 
 public class SheetSummaryResourcesImpl extends AbstractResources implements SheetSummaryResources {
+    private static final String SHEETS_PATH = "sheets/";
+
+    private static final String SUMMARY = "summary";
+    private static final String FIELDS = "fields";
+    private static final String IMAGES = "images";
+    private static final String RENAME_IF_CONFLICT = "renameIfConflict";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -71,7 +76,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Gets the sheet summary
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{id}/summary
      *
      * @param sheetId the sheet id
@@ -86,8 +91,12 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws SmartsheetException if there is any other error during the operation
      **/
     @Override
-    public SheetSummary getSheetSummary(long sheetId, EnumSet<SummaryFieldInclusion> includes, EnumSet<SummaryFieldExclusion> excludes) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/summary";
+    public SheetSummary getSheetSummary(
+            long sheetId,
+            EnumSet<SummaryFieldInclusion> includes,
+            EnumSet<SummaryFieldExclusion> excludes
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/summary";
 
         // Add the parameters to a map and build the query string at the end
         Map<String, Object> parameters = new HashMap<>();
@@ -103,7 +112,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Gets the sheet summary fields
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{id}/summary/fields
      *
      * @param sheetId the sheet id
@@ -121,7 +130,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
     public PagedResult<SummaryField> getSheetSummaryFields(long sheetId, EnumSet<SummaryFieldInclusion> includes,
                                                            EnumSet<SummaryFieldExclusion> excludes,
                                                            PaginationParameters pagination) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/summary/fields";
+        String path = SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS;
 
         Map<String, Object> parameters = new HashMap<>();
         if (pagination != null) {
@@ -136,7 +145,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Insert fields into a sheet summary.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/summary/fields
      *
      * @param sheetId the sheet id
@@ -150,11 +159,15 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public List<SummaryField> addSheetSummaryFields(long sheetId, List<SummaryField> fields, Boolean renameIfConflict) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/summary/fields";
+    public List<SummaryField> addSheetSummaryFields(
+            long sheetId,
+            List<SummaryField> fields,
+            Boolean renameIfConflict
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS;
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("renameIfConflict", renameIfConflict);
+        parameters.put(RENAME_IF_CONFLICT, renameIfConflict);
 
         path += QueryUtil.generateUrl(null, parameters);
         return this.postAndReceiveList(path, fields, SummaryField.class);
@@ -162,7 +175,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Insert fields into a sheet summary.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/summary/fields
      *
      * @param sheetId the sheet id
@@ -183,7 +196,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Update fields in a sheet summary.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/summary/fields
      *
      * @param sheetId the sheet id
@@ -197,11 +210,15 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public List<SummaryField> updateSheetSummaryFields(long sheetId, List<SummaryField> fields, Boolean renameIfConflict) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/summary/fields";
+    public List<SummaryField> updateSheetSummaryFields(
+            long sheetId,
+            List<SummaryField> fields,
+            Boolean renameIfConflict
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS;
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("renameIfConflict", renameIfConflict);
+        parameters.put(RENAME_IF_CONFLICT, renameIfConflict);
 
         path += QueryUtil.generateUrl(null, parameters);
         return this.putAndReceiveList(path, fields, SummaryField.class);
@@ -209,7 +226,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Update fields in a sheet summary.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/summary/fields
      *
      * @param sheetId the sheet id
@@ -230,7 +247,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Delete fields in a sheet summary.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/summary/fields
      *
      * @param sheetId the sheet id
@@ -244,9 +261,13 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public List<Long> deleteSheetSummaryFields(long sheetId, Set<Long> fieldIds, Boolean ignoreSummaryFieldsNotFound) throws SmartsheetException {
+    public List<Long> deleteSheetSummaryFields(
+            long sheetId,
+            Set<Long> fieldIds,
+            Boolean ignoreSummaryFieldsNotFound
+    ) throws SmartsheetException {
         Map<String, Object> parameters = new HashMap<>();
-        String path = "sheets/" + sheetId + "/summary/fields";
+        String path = SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS;
         parameters.put("ids", QueryUtil.generateCommaSeparatedList(fieldIds));
         parameters.put("ignoreSummaryFieldsNotFound", ignoreSummaryFieldsNotFound);
 
@@ -257,7 +278,7 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
 
     /**
      * Adds an image to the sheet summary field.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/summary/fields/{fieldId}/images
      *
      * @param sheetId the sheet id
@@ -273,16 +294,28 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Result<SummaryField> addSheetSummaryFieldImage(long sheetId, long fieldId, String file, String contentType, String altText) throws SmartsheetException, FileNotFoundException {
+    public Result<SummaryField> addSheetSummaryFieldImage(
+            long sheetId,
+            long fieldId,
+            String file,
+            String contentType,
+            String altText
+    ) throws SmartsheetException, FileNotFoundException {
         Util.throwIfNull(file);
         File f = new File(file);
-        return addSheetSummaryFieldImage("sheets/" + sheetId + "/summary/fields/" + fieldId + "/images", new FileInputStream(f),
-            contentType, f.length(), altText, file);
+        return addSheetSummaryFieldImage(
+                SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS + "/" + fieldId + "/" + IMAGES,
+                new FileInputStream(f),
+                contentType,
+                f.length(),
+                altText,
+                file
+        );
     }
 
     /**
      * Adds an image to the sheet summary field.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/summary/fields/{fieldId}/images
      *
      * @param sheetId the sheet id
@@ -298,15 +331,27 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Result<SummaryField> addSheetSummaryFieldImage(long sheetId, long fieldId, File file, String contentType, String altText) throws SmartsheetException, FileNotFoundException {
+    public Result<SummaryField> addSheetSummaryFieldImage(
+            long sheetId,
+            long fieldId,
+            File file,
+            String contentType,
+            String altText
+    ) throws SmartsheetException, FileNotFoundException {
         Util.throwIfNull(file);
-        return addSheetSummaryFieldImage("sheets/" + sheetId + "/summary/fields/" + fieldId + "/images", new FileInputStream(file),
-                contentType, file.length(), altText, file.getName());
+        return addSheetSummaryFieldImage(
+                SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS + "/" + fieldId + "/" + IMAGES,
+                new FileInputStream(file),
+                contentType,
+                file.length(),
+                altText,
+                file.getName()
+        );
     }
 
     /**
      * Adds an image to the sheet summary field.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/summary/fields/{fieldId}/images
      *
      * @param sheetId the sheet id
@@ -323,16 +368,28 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public Result<SummaryField> addSheetSummaryFieldImage(long sheetId, long fieldId, InputStream inputStream, String contentType,
-                                                          long contentLength, String altText) throws SmartsheetException, FileNotFoundException {
+    public Result<SummaryField> addSheetSummaryFieldImage(
+            long sheetId,
+            long fieldId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String altText
+    ) throws SmartsheetException, FileNotFoundException {
         Util.throwIfNull(inputStream);
-        return addSheetSummaryFieldImage("sheets/" + sheetId + "/summary/fields/" + fieldId + "/images", inputStream,
+        return addSheetSummaryFieldImage(SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS + "/" + fieldId + "/" + IMAGES, inputStream,
                 contentType, contentLength, altText, altText);
     }
 
-    private Result<SummaryField> addSheetSummaryFieldImage(String path, InputStream inputStream, String contentType, long contentLength,
-                                                           String altText, String imageName) throws SmartsheetException, FileNotFoundException {
-        if(imageName == null) {
+    private Result<SummaryField> addSheetSummaryFieldImage(
+            String path,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String altText,
+            String imageName
+    ) throws SmartsheetException, FileNotFoundException {
+        if (imageName == null) {
             inputStream.toString();
         }
         if (contentType == null) {
@@ -369,12 +426,16 @@ public class SheetSummaryResourcesImpl extends AbstractResources implements Shee
         return obj;
     }
 
-    private BulkItemResult<SummaryField> doBulkOperation (long sheetId, List<SummaryField> fields,
-                                                          Boolean renameIfConflict, HttpMethod method) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/summary/fields";
+    private BulkItemResult<SummaryField> doBulkOperation(
+            long sheetId,
+            List<SummaryField> fields,
+            Boolean renameIfConflict,
+            HttpMethod method
+    ) throws SmartsheetException {
+        String path = SHEETS_PATH + sheetId + "/" + SUMMARY + "/" + FIELDS;
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("allowPartialSuccess", "true");
-        parameters.put("renameIfConflict", renameIfConflict);
+        parameters.put(RENAME_IF_CONFLICT, renameIfConflict);
 
         path = QueryUtil.generateUrl(path, parameters);
 

--- a/src/main/java/com/smartsheet/api/internal/SheetUpdateRequestResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetUpdateRequestResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,10 +36,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SheetUpdateRequestResourcesImpl extends AbstractResources implements SheetUpdateRequestResources {
+    private static final String SHEETS_PATH = "sheets/";
+    private static final String UPDATE_REQUESTS = "updaterequests";
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -49,7 +52,7 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
 
     /**
      * Gets a list of all Update Requests that have future schedules associated with the specified Sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/updaterequests
      *
      * @param paging the object containing the pagination parameters
@@ -62,7 +65,7 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public PagedResult<UpdateRequest> listUpdateRequests(long sheetId, PaginationParameters paging) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/updaterequests";
+        String path = SHEETS_PATH + sheetId + "/" + UPDATE_REQUESTS;
 
         Map<String, Object> parameters = new HashMap<>();
         if (paging != null) {
@@ -75,12 +78,13 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
 
     /**
      * Gets the specified Update Request for the Sheet that has a future schedule.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sheets/{sheetId}/updaterequests/{updateRequestId}
      *
      * @param sheetId the Id of the sheet
      * @param updateRequestId the update request Id
-     * @return the update request resource (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null).
+     * @return the update request resource (note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -89,14 +93,14 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public UpdateRequest getUpdateRequest(long sheetId, long updateRequestId) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/updaterequests/" + updateRequestId;
+        String path = SHEETS_PATH + sheetId + "/" + UPDATE_REQUESTS + "/" + updateRequestId;
         return this.getResource(path, UpdateRequest.class);
     }
 
     /**
      * Creates an Update Request for the specified Row(s) within the Sheet. An email notification
      * (containing a link to the update request) will be asynchronously sent to the specified recipient(s).
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/updaterequests
      *
      * @param sheetId the Id of the sheet
@@ -110,13 +114,13 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public UpdateRequest createUpdateRequest(long sheetId, UpdateRequest updateRequest) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/updaterequests";
+        String path = SHEETS_PATH + sheetId + "/" + UPDATE_REQUESTS;
         return this.createResource(path, UpdateRequest.class, updateRequest);
     }
 
     /**
      * Terminates the future scheduled delivery of the Update Request specified in the URL.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sheets/{sheetId}/updaterequests/{updateRequestId}
      *
      * @param sheetId the Id of the sheet
@@ -129,13 +133,13 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void deleteUpdateRequest(long sheetId, long updateRequestId) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/updaterequests/" + updateRequestId;
+        String path = SHEETS_PATH + sheetId + "/" + UPDATE_REQUESTS + "/" + updateRequestId;
         this.deleteResource(path, UpdateRequest.class);
     }
 
     /**
      * Changes the specified Update Request for the Sheet.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /sheets/{sheetId}/updaterequests/{updateRequestId}
      *
      * @param sheetId the Id of the sheet
@@ -149,13 +153,13 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public UpdateRequest updateUpdateRequest(long sheetId, UpdateRequest updateRequest) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/updaterequests/" + updateRequest.getId();
+        String path = SHEETS_PATH + sheetId + "/" + UPDATE_REQUESTS + "/" + updateRequest.getId();
         return this.updateResource(path, UpdateRequest.class, updateRequest);
     }
 
     /**
      * Gets a list of all Sent Update Requests that have future schedules associated with the specified Sheet.
-     *
+     * <p>
      * It mirrors To the following Smartsheet REST API method: GET /sheets/{sheetId}/sentupdaterequests
      *
      * @param sheetId the Id of the sheet
@@ -169,7 +173,7 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public PagedResult<SentUpdateRequest> listSentUpdateRequests(long sheetId, PaginationParameters paging) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/sentupdaterequests";
+        String path = SHEETS_PATH + sheetId + "/sentupdaterequests";
 
         Map<String, Object> parameters = new HashMap<>();
         if (paging != null) {
@@ -182,12 +186,13 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
 
     /**
      * Gets the specified sent update request on the Sheet.
-     *
+     * <p>
      * It mirrors To the following Smartsheet REST API method: GET /sheets/{sheetId}/sentupdaterequests/{updateRequestId}
      *
      * @param sheetId the Id of the sheet
      * @param sentUpdateRequestId the sent update request Id
-     * @return the sent update request resource (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null).
+     * @return the sent update request resource (note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -196,13 +201,13 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public SentUpdateRequest getSentUpdateRequest(long sheetId, long sentUpdateRequestId) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/sentupdaterequests/" + sentUpdateRequestId;
+        String path = SHEETS_PATH + sheetId + "/sentupdaterequests/" + sentUpdateRequestId;
         return this.getResource(path, SentUpdateRequest.class);
     }
 
     /**
      * Deletes the specified sent update request.
-     *
+     * <p>
      * It mirrors To the following Smartsheet REST API method: DELETE /sheets/{sheetId}/sentupdaterequests/{sentUpdateRequestId}
      *
      * @param sheetId the Id of the sheet
@@ -215,7 +220,7 @@ public class SheetUpdateRequestResourcesImpl extends AbstractResources implement
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void deleteSentUpdateRequest(long sheetId, long sentUpdateRequestId) throws SmartsheetException {
-        String path = "sheets/" + sheetId + "/sentupdaterequests/" + sentUpdateRequestId;
+        String path = SHEETS_PATH + sheetId + "/sentupdaterequests/" + sentUpdateRequestId;
         this.deleteResource(path, SentUpdateRequest.class);
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/SightResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SightResourcesImpl.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,23 +46,25 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
 
     private ShareResources shares;
 
+    private static final String SIGHTS = "sights";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
      */
     public SightResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
-        this.shares = new ShareResourcesImpl(smartsheet, "sights");
+        this.shares = new ShareResourcesImpl(smartsheet, SIGHTS);
     }
+
     /**
      * Gets the list of all Sights where the User has access.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sights
      *
-     * @param modifiedSince
      * @return IndexResult object containing an array of Sight objects limited to the following attributes:
      *     id, name, accessLevel, permalink, createdAt, modifiedAt.
      * @throws IllegalArgumentException if any argument is null or empty string
@@ -73,7 +75,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public PagedResult<Sight> listSights(PaginationParameters paging, Date modifiedSince) throws SmartsheetException {
-        String path = "sights";
+        String path = SIGHTS;
 
         Map<String, Object> parameters = new HashMap<>();
         if (paging != null) {
@@ -89,7 +91,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
 
     /**
      * Get a specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sights/{sightId}
      *
      * @param sightId the Id of the Sight
@@ -107,7 +109,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
 
     /**
      * Get a specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sights/{sightId}
      *
      * @param sightId the Id of the Sight
@@ -126,7 +128,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
 
     /**
      * Get a specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /sights/{sightId}
      *
      * @param sightId the Id of the Sight
@@ -141,7 +143,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Sight getSight(long sightId, EnumSet<SightInclusion> includes, Integer level) throws SmartsheetException {
-        String path = "sights/" + sightId;
+        String path = SIGHTS + "/" + sightId;
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("level", level);
@@ -153,7 +155,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
 
     /**
      * Update a specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /sights/{sightId}
      *
      * @param sight - the Sight to update
@@ -167,12 +169,12 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      */
     public Sight updateSight(Sight sight) throws SmartsheetException {
         Util.throwIfNull(sight);
-        return this.updateResource("sights/" + sight.getId(), Sight.class, sight);
+        return this.updateResource(SIGHTS + "/" + sight.getId(), Sight.class, sight);
     }
 
     /**
      * Delete a specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /sights/{sightId}
      *
      * @param sightId the Id of the Sight
@@ -185,12 +187,12 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void deleteSight(long sightId) throws SmartsheetException {
-        this.deleteResource("sights/" + sightId, Sight.class);
+        this.deleteResource(SIGHTS + "/" + sightId, Sight.class);
     }
 
     /**
      * Creates s copy of the specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sights/{sightId}/copy
      *
      * @param sightId the Id of the Sight
@@ -204,12 +206,12 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Sight copySight(long sightId, ContainerDestination destination) throws SmartsheetException {
-        return this.createResource("sights/" + sightId + "/copy", Sight.class, destination);
+        return this.createResource(SIGHTS + "/" + sightId + "/copy", Sight.class, destination);
     }
 
     /**
      * Creates s copy of the specified Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sights/{sightId}/move
      *
      * @param sightId the Id of the Sight
@@ -223,12 +225,12 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Sight moveSight(long sightId, ContainerDestination destination) throws SmartsheetException {
-        return this.createResource("sights/" + sightId + "/move", Sight.class, destination);
+        return this.createResource(SIGHTS + "/" + sightId + "/move", Sight.class, destination);
     }
 
     /**
      * Get the publish status of a Sight.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sights/{sightId}/publish
      *
      * @param sightId the Id of the Sight
@@ -241,12 +243,12 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      * @throws SmartsheetException if there is any other error during the operation
      */
     public SightPublish getPublishStatus(long sightId) throws SmartsheetException {
-        return this.getResource("sights/" + sightId + "/publish", SightPublish.class);
+        return this.getResource(SIGHTS + "/" + sightId + "/publish", SightPublish.class);
     }
 
     /**
      * Sets the publish status of a Sight and returns the new status, including the URLs of any enabled publishing.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sights/{sightId}/publish
      *
      * @param sightId the Id of the Sight
@@ -261,7 +263,7 @@ public class SightResourcesImpl extends AbstractResources implements SightResour
      */
     public SightPublish setPublishStatus(long sightId, SightPublish sightPublish) throws SmartsheetException {
         Util.throwIfNull(sightPublish);
-        return this.updateResource("sights/" + sightId + "/publish", SightPublish.class, sightPublish);
+        return this.updateResource(SIGHTS + "/" + sightId + "/publish", SightPublish.class, sightPublish);
     }
 
     /**

--- a/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.ContactResources;
 import com.smartsheet.api.EventResources;
@@ -57,7 +56,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This is the implementation of Smartsheet interface.
- *
+ * <p>
  * Thread Safety: This class is thread safe because all its mutable fields are safe-guarded using AtomicReference to
  * ensure atomic modifications, and also the underlying HttpClient and JsonSerializer interfaces are thread safe.
  */
@@ -65,14 +64,14 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the base URI of the Smartsheet REST API.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private URI baseURI;
 
     /**
      * Represents the AtomicReference for access token.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and can be set via corresponding setter, therefore effectively the access token can be updated in the
      * SmartsheetImpl in thread safe manner.
@@ -81,21 +80,21 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the HttpClient.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private final HttpClient httpClient;
 
     /**
      * Represents the JsonSerializer.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private JsonSerializer jsonSerializer;
 
     /**
      * Represents the AtomicReference for assumed user email.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and can be set via corresponding setter, therefore effectively the assumed user can be updated in the
      * SmartsheetImpl in thread safe manner.
@@ -104,7 +103,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for change agent
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      *
      */
@@ -117,7 +116,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to HomeResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -126,7 +125,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to WorkspaceResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -135,7 +134,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to FolderResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -144,7 +143,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to TemplateResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -153,7 +152,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to SheetResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -162,7 +161,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to SightResources
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -171,7 +170,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to UserResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -180,7 +179,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to {@link GroupResources}.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -189,7 +188,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to SearchResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -198,7 +197,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference to ReportResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -207,7 +206,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for ServerInfoResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -216,7 +215,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for FavoriteResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -225,7 +224,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for TokenResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -234,7 +233,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for ContactResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -243,7 +242,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for ImageUrlResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -252,7 +251,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for WebhookResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -261,7 +260,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for PassthroughResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
@@ -270,16 +269,18 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Represents the AtomicReference for EventResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
      * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
      * effectively the underlying value is lazily created in a thread safe manner.
      */
     private final AtomicReference<EventResources> events;
 
+    private static final String INVALID_OPERATION_FOR_CLASS = "Invalid operation for class ";
+
     /**
      * Create an instance with given server URI, HttpClient (optional) and JsonSerializer (optional)
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if serverURI/version/accessToken is null/empty
      *
      * @param baseURI the server uri
@@ -291,7 +292,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Create an instance with given server URI, HttpClient (optional) and JsonSerializer (optional)
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if serverURI/version/accessToken is null/empty
      *
      * @param baseURI the server uri
@@ -305,9 +306,9 @@ public class SmartsheetImpl implements Smartsheet {
 
         this.baseURI = URI.create(baseURI);
         this.accessToken = new AtomicReference<>(accessToken);
-        this.jsonSerializer = ((jsonSerializer == null) ? new JacksonJsonSerializer() : jsonSerializer);
-        this.httpClient = ((httpClient == null) ?
-                new DefaultHttpClient(HttpClients.createDefault(), this.jsonSerializer) :  httpClient);
+        this.jsonSerializer = (jsonSerializer == null) ? new JacksonJsonSerializer() : jsonSerializer;
+        this.httpClient = (httpClient == null)
+                ? new DefaultHttpClient(HttpClients.createDefault(), this.jsonSerializer) : httpClient;
         this.assumedUser = new AtomicReference<>(null);
         this.changeAgent = new AtomicReference<>(null);
         this.userAgent = new AtomicReference<>(generateUserAgent(null));
@@ -344,7 +345,7 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Getter of corresponding field.
-     *
+     * <p>
      * Returns: corresponding field.
      *
      * @return the base uri
@@ -364,11 +365,11 @@ public class SmartsheetImpl implements Smartsheet {
 
     /**
      * Set the access token to use.
-     *
+     * <p>
      * Parameters: - accessToken : the access token
-     *
+     * <p>
      * Returns: None
-     *
+     * <p>
      *
      * @param accessToken the new access token
      */
@@ -424,7 +425,6 @@ public class SmartsheetImpl implements Smartsheet {
     /**
      * Sets the change agent identifier
      *
-     * @param changeAgent
      */
     public void setChangeAgent(String changeAgent) {
         this.changeAgent.set(changeAgent);
@@ -456,30 +456,29 @@ public class SmartsheetImpl implements Smartsheet {
     public void setMaxRetryTimeMillis(long maxRetryTimeMillis) {
         if (this.httpClient instanceof DefaultHttpClient) {
             ((DefaultHttpClient) this.httpClient).setMaxRetryTimeMillis(maxRetryTimeMillis);
-        }
-        else if (this.httpClient instanceof AndroidHttpClient) {
+        } else if (this.httpClient instanceof AndroidHttpClient) {
             ((AndroidHttpClient) this.httpClient).setMaxRetryTimeMillis(maxRetryTimeMillis);
+        } else {
+            throw new UnsupportedOperationException(INVALID_OPERATION_FOR_CLASS + this.httpClient.getClass());
         }
-        else
-            throw new UnsupportedOperationException("Invalid operation for class " + this.httpClient.getClass());
     }
 
     /** set what request/response fields to log in trace-logging */
     public void setTraces(Trace... traces) {
         if (this.httpClient instanceof DefaultHttpClient) {
-            ((DefaultHttpClient)this.httpClient).setTraces(traces);
+            ((DefaultHttpClient) this.httpClient).setTraces(traces);
+        } else {
+            throw new UnsupportedOperationException(INVALID_OPERATION_FOR_CLASS + this.httpClient.getClass());
         }
-        else
-            throw new UnsupportedOperationException("Invalid operation for class " + this.httpClient.getClass());
     }
 
     /** set whether or not to generate "pretty formatted" JSON in trace-logging */
     public void setTracePrettyPrint(boolean pretty) {
         if (this.httpClient instanceof DefaultHttpClient) {
-            ((DefaultHttpClient)this.httpClient).setTracePrettyPrint(pretty);
+            ((DefaultHttpClient) this.httpClient).setTracePrettyPrint(pretty);
+        } else {
+            throw new UnsupportedOperationException(INVALID_OPERATION_FOR_CLASS + this.httpClient.getClass());
         }
-        else
-            throw new UnsupportedOperationException("Invalid operation for class " + this.httpClient.getClass());
     }
 
     /**
@@ -553,6 +552,7 @@ public class SmartsheetImpl implements Smartsheet {
         }
         return sights.get();
     }
+
     /**
      * Returns the FavoriteResources instance that provides access to Favorite resources.
      *
@@ -706,12 +706,12 @@ public class SmartsheetImpl implements Smartsheet {
         String title = null;
         String thisVersion = null;
 
-        if(userAgent == null) {
+        if (userAgent == null) {
             StackTraceElement[] callers = Thread.currentThread().getStackTrace();
             String module = null;
             String callerClass = null;
             int stackIdx;
-            for(stackIdx = callers.length - 1; stackIdx >= 0; stackIdx--) {
+            for (stackIdx = callers.length - 1; stackIdx >= 0; stackIdx--) {
                 callerClass = callers[stackIdx].getClassName();
                 try {
                     Class<?> clazz = Class.forName(callerClass);
@@ -732,7 +732,9 @@ public class SmartsheetImpl implements Smartsheet {
                             break;
                         }
                     }
-                } catch (Exception ex) { }
+                } catch (Exception ex) {
+                    // Empty Catch Block
+                }
             }
             userAgent = module + "!" + callerClass;
         }
@@ -741,9 +743,11 @@ public class SmartsheetImpl implements Smartsheet {
             properties.load(this.getClass().getClassLoader().getResourceAsStream("sdk.properties"));
             thisVersion = properties.getProperty("sdk.version");
             title = properties.getProperty("sdk.name");
-        } catch (IOException e) { }
-        return title + "/" + thisVersion + "/" + userAgent + "/" + System.getProperty("os.name") + " "
-                + System.getProperty("java.vm.name") + " " + System.getProperty("java.vendor") + " "
-                + System.getProperty("java.version");
+        } catch (IOException e) {
+            // Empty Catch Block
+        }
+        return title + "/" + thisVersion + "/" + userAgent + "/" + System.getProperty("os.name") + " " +
+                System.getProperty("java.vm.name") + " " + System.getProperty("java.vendor") + " " +
+                System.getProperty("java.version");
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/TemplateResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/TemplateResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.TemplateResources;
@@ -30,14 +28,14 @@ import com.smartsheet.api.models.Template;
 
 /**
  * This is the implementation of the TemplateResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class TemplateResourcesImpl extends AbstractResources implements TemplateResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is
      *
      * @param smartsheet the smartsheet
@@ -48,10 +46,9 @@ public class TemplateResourcesImpl extends AbstractResources implements Template
 
     /**
      * List user-created templates.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /templates
-     *
-     * @param parameters the pagination parameters
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -59,6 +56,7 @@ public class TemplateResourcesImpl extends AbstractResources implements Template
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
+     * @param parameters the pagination parameters
      * @return all templates (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
@@ -74,10 +72,9 @@ public class TemplateResourcesImpl extends AbstractResources implements Template
 
     /**
      * List public templates.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /templates/public
-     *
-     * @param parameters the pagination parameters
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -85,6 +82,7 @@ public class TemplateResourcesImpl extends AbstractResources implements Template
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
+     * @param parameters the pagination parameters
      * @return all templates (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */

--- a/src/main/java/com/smartsheet/api/internal/TokenResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/TokenResourcesImpl.java
@@ -41,7 +41,7 @@ public class TokenResourcesImpl extends AbstractResources implements TokenResour
      *
      * @throws NoSuchMethodException method implemented in OAuthFlow
      */
-    public void getAccessToken() throws NoSuchMethodException{
+    public void getAccessToken() throws NoSuchMethodException {
         throw new NoSuchMethodException("Not implemented in TokenResources. Refer OAuthFlow.");
     }
 
@@ -56,8 +56,8 @@ public class TokenResourcesImpl extends AbstractResources implements TokenResour
      * @throws InvalidRequestException the invalid request exception
      */
     public void revokeAccessToken() throws OAuthTokenException, JSONSerializerException, HttpClientException,
-            URISyntaxException, InvalidRequestException, SmartsheetException{
-     this.deleteResource("token", Token.class);
+            URISyntaxException, InvalidRequestException, SmartsheetException {
+        this.deleteResource("token", Token.class);
     }
 
     /**
@@ -65,7 +65,7 @@ public class TokenResourcesImpl extends AbstractResources implements TokenResour
      *
      * @throws NoSuchMethodException exception that is always thrown
     */
-    public void refreshAccessToken() throws NoSuchMethodException{
+    public void refreshAccessToken() throws NoSuchMethodException {
         throw new NoSuchMethodException("Not implemented in TokenResources. Refer OAuthFlow.");
     }
 }

--- a/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
@@ -58,14 +58,17 @@ import java.util.Set;
 
 /**
  * This is the implementation of the UserResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class UserResourcesImpl extends AbstractResources implements UserResources {
 
+    private static final String USERS = "users";
+    private static final String ALTERNATE_EMAILS = "alternateemails";
+
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null
      *
      * @param smartsheet the smartsheet
@@ -76,7 +79,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     /**
      * List all users.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users
      *
      * @return the list of all users
@@ -88,14 +91,14 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws SmartsheetException if there is any other error during the operation
      */
     public PagedResult<User> listUsers() throws SmartsheetException {
-        return this.listResourcesWithWrapper("users", User.class);
+        return this.listResourcesWithWrapper(USERS, User.class);
     }
 
     /**
      * List all users.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -114,9 +117,9 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     /**
      * List all users.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -132,10 +135,10 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      */
     public PagedResult<User> listUsers(Set<String> email, EnumSet<ListUserInclusion> includes,
                                        PaginationParameters pagination) throws SmartsheetException {
-        String path = "users";
+        String path = USERS;
         Map<String, Object> parameters = new HashMap<>();
 
-        if (pagination != null){
+        if (pagination != null) {
             parameters = pagination.toHashMap();
         }
         parameters.put("email", QueryUtil.generateCommaSeparatedList(email));
@@ -147,9 +150,9 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     /**
      * Add a user to the organization, without sending email.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /users
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if any argument is null
      *   - InvalidRequestException : if there is any problem with the REST API request
@@ -164,14 +167,14 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws SmartsheetException the smartsheet exception
      */
     public User addUser(User user) throws SmartsheetException {
-        return this.createResource("users", User.class, user);
+        return this.createResource(USERS, User.class, user);
     }
 
     /**
      * Add a user to the organization, without sending email.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /users
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if any argument is null
      *   - InvalidRequestException : if there is any problem with the REST API request
@@ -192,7 +195,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     /**
      * Get the current user.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users/{userId}
      *
      * @param userId the user id
@@ -205,14 +208,14 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws SmartsheetException if there is any other error during the operation
      */
     public UserProfile getUser(long userId) throws SmartsheetException {
-        return this.getResource("users/" + userId, UserProfile.class);
+        return this.getResource(USERS + "/" + userId, UserProfile.class);
     }
 
     /**
      * Get the current user.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users/me
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -222,7 +225,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public UserProfile getCurrentUser() throws SmartsheetException {
@@ -255,11 +258,10 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     /**
      * List all organisation sheets.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users/sheets
      *
      * @param pagination the object containing the pagination query parameters
-     * @param modifiedSince
      * @return the list of all organisation sheets
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
@@ -282,13 +284,14 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
         path += QueryUtil.generateUrl(null, parameters);
         return this.listResourcesWithWrapper(path, Sheet.class);
     }
+
     public PagedResult<Sheet> listOrgSheets(PaginationParameters pagination) throws SmartsheetException {
         return this.listOrgSheets(pagination, null);
     }
 
     /**
      * List all user alternate emails.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users/{userId}/alternateemails
      *
      * @param userId the id of the user
@@ -301,8 +304,8 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    public PagedResult<AlternateEmail> listAlternateEmails(long userId, PaginationParameters pagination) throws SmartsheetException    {
-        String path = "users/" + userId + "/alternateemails";
+    public PagedResult<AlternateEmail> listAlternateEmails(long userId, PaginationParameters pagination) throws SmartsheetException {
+        String path = USERS + "/" + userId + "/" + ALTERNATE_EMAILS;
 
         if (pagination != null) {
             path += pagination.toQueryString();
@@ -312,7 +315,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     /**
      * Get alternate email.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /users/{userId}/alternateemails/{alternateEmailId}
      *
      * @param userId the id of the user
@@ -327,12 +330,12 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws SmartsheetException if there is any other error during the operation
      */
     public AlternateEmail getAlternateEmail(long userId, long altEmailId) throws SmartsheetException {
-        return this.getResource("users/" + userId + "/alternateemails/" + altEmailId, AlternateEmail.class);
+        return this.getResource(USERS + "/" + userId + "/" + ALTERNATE_EMAILS + "/" + altEmailId, AlternateEmail.class);
     }
 
     /**
      * Add an alternate email.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /users/{userId}/alternateemails
      *
      * @param userId the id of the user
@@ -351,12 +354,12 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
         if (altEmails.size() == 0) {
             return altEmails;
         }
-        return this.postAndReceiveList("users/" + userId + "/alternateemails", altEmails, AlternateEmail.class);
+        return this.postAndReceiveList(USERS + "/" + userId + "/" + ALTERNATE_EMAILS, altEmails, AlternateEmail.class);
     }
 
     /**
      * Delete an alternate email.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /users/{userId}/alternateemails/{alternateEmailId}
      *
      * @param userId the id of the user
@@ -369,7 +372,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void deleteAlternateEmail(long userId, long altEmailId) throws SmartsheetException {
-        this.deleteResource("users/" + userId + "/alternateemails/" + altEmailId, AlternateEmail.class);
+        this.deleteResource(USERS + "/" + userId + "/" + ALTERNATE_EMAILS + "/" + altEmailId, AlternateEmail.class);
     }
 
     /**
@@ -388,7 +391,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
     public AlternateEmail promoteAlternateEmail(long userId, long altEmailId) throws SmartsheetException {
 
         HttpRequest request = createHttpRequest(smartsheet.getBaseURI().resolve(
-                "users/" + userId + "/alternateemails/" + altEmailId + "/makeprimary"), HttpMethod.POST);
+                USERS + "/" + userId + "/" + ALTERNATE_EMAILS + "/" + altEmailId + "/makeprimary"), HttpMethod.POST);
 
         Object obj = null;
         try {
@@ -405,7 +408,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
             smartsheet.getHttpClient().releaseConnection();
         }
 
-        return (AlternateEmail)obj;
+        return (AlternateEmail) obj;
     }
 
     /**
@@ -423,13 +426,13 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @throws SmartsheetException f there is any other error during the operation
      */
     public User addProfileImage(long userId, String file, String fileType) throws SmartsheetException, FileNotFoundException {
-        return attachProfileImage("users/" + userId + "/profileimage", file, fileType);
+        return attachProfileImage(USERS + "/" + userId + "/profileimage", file, fileType);
     }
 
     private User attachProfileImage(String path, String file, String contentType) throws SmartsheetException, FileNotFoundException {
         Util.throwIfNull(file);
 
-        if(contentType == null) {
+        if (contentType == null) {
             contentType = "application/octet-stream";
         }
 
@@ -469,12 +472,12 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
     @Override
     public User updateUser(User user) throws SmartsheetException {
-        return this.updateResource("users/" + user.getId(), User.class, user);
+        return this.updateResource(USERS + "/" + user.getId(), User.class, user);
     }
 
     @Override
     public void deleteUser(long userId, DeleteUserParameters parameters) throws SmartsheetException {
-        String path = "users/" + userId;
+        String path = USERS + "/" + userId;
 
         if (parameters != null) {
             path += parameters.toQueryString();

--- a/src/main/java/com/smartsheet/api/internal/WebhookResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/WebhookResourcesImpl.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,6 +42,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class WebhookResourcesImpl extends AbstractResources implements WebhookResources {
+    private static final String WEBHOOKS_PATH = "webhooks/";
 
     public WebhookResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
@@ -50,7 +52,7 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
      * Gets the list of all Webhooks that the user owns (if a user generated token was used to make the request)
      * or the list of all Webhooks associated with the third-party app (if a third-party app made the request). Items
      * in the response are ordered by API Client name, then Webhook name, then creation date.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /webhooks
      *
      * @param paging the object containing the pagination parameters
@@ -76,7 +78,7 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
 
     /**
      * Gets the Webhook specified in the URL.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /webhooks/{webhookId}
      *
      * @param webhookId the Id of the webhook
@@ -89,12 +91,12 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Webhook getWebhook(long webhookId) throws SmartsheetException {
-        return this.getResource("webhooks/" + webhookId, Webhook.class);
+        return this.getResource(WEBHOOKS_PATH + webhookId, Webhook.class);
     }
 
     /**
      * Creates a new Webhook.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /webhooks
      *
      * @param webhook the webhook to be created
@@ -112,12 +114,11 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
 
     /**
      * Updates the webhooks specified in the URL.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /webhooks/{webhookId}
      *
      * @param webhook the webhook to update
      * @return the updated webhook resource.
-     * @throws SmartsheetException
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -125,12 +126,12 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      */
     public Webhook updateWebhook(Webhook webhook) throws SmartsheetException {
-        return this.updateResource("webhooks/" + webhook.getId(), Webhook.class, webhook);
+        return this.updateResource(WEBHOOKS_PATH + webhook.getId(), Webhook.class, webhook);
     }
 
     /**
      * Delete a webhook.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /webhooks/{webhookId}
      *
      * @param webhookId the webhook Id
@@ -142,13 +143,13 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
      * @throws SmartsheetException if there is any other error during the operation
      */
     public void deleteWebhook(long webhookId) throws SmartsheetException {
-        this.deleteResource("webhooks/" + webhookId, Webhook.class);
+        this.deleteResource(WEBHOOKS_PATH + webhookId, Webhook.class);
     }
 
     /**
      * Resets the shared secret for the specified Webhook. For more information about how a shared secret is used,
      *  see Authenticating Callbacks.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /webhooks/{webhookId}/resetsharedsecret
      *
      * @param webhookId the webhook Id
@@ -161,27 +162,27 @@ public class WebhookResourcesImpl extends AbstractResources implements WebhookRe
      * @throws SmartsheetException if there is any other error during the operation
      */
     public WebhookSharedSecret resetSharedSecret(long webhookId) throws SmartsheetException {
-        HttpRequest request = createHttpRequest(this.getSmartsheet().getBaseURI().resolve("webhooks/" +
+        HttpRequest request = createHttpRequest(this.getSmartsheet().getBaseURI().resolve(WEBHOOKS_PATH +
                 webhookId + "/resetsharedsecret"), HttpMethod.POST);
 
         HttpResponse response = getSmartsheet().getHttpClient().request(request);
 
         WebhookSharedSecret secret = null;
         switch (response.getStatusCode()) {
-        case 200:
-            try {
-                secret = this.smartsheet.getJsonSerializer().deserialize(WebhookSharedSecret.class,
-                    response.getEntity().getContent());
-            } catch (JsonParseException e) {
-                throw new SmartsheetException(e);
-            } catch (JsonMappingException e) {
-                throw new SmartsheetException(e);
-            } catch (IOException e) {
-                throw new SmartsheetException(e);
-            }
-            break;
-        default:
-            handleError(response);
+            case 200:
+                try {
+                    secret = this.smartsheet.getJsonSerializer().deserialize(WebhookSharedSecret.class,
+                        response.getEntity().getContent());
+                } catch (JsonParseException e) {
+                    throw new SmartsheetException(e);
+                } catch (JsonMappingException e) {
+                    throw new SmartsheetException(e);
+                } catch (IOException e) {
+                    throw new SmartsheetException(e);
+                }
+                break;
+            default:
+                handleError(response);
         }
 
         getSmartsheet().getHttpClient().releaseConnection();

--- a/src/main/java/com/smartsheet/api/internal/WorkspaceFolderResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/WorkspaceFolderResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.WorkspaceFolderResources;
@@ -29,14 +28,14 @@ import com.smartsheet.api.models.PaginationParameters;
 
 /**
  * This is the implementation of the WorkspaceFolderResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class WorkspaceFolderResourcesImpl extends AbstractResources implements WorkspaceFolderResources {
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is
      *
      * @param smartsheet the smartsheet
@@ -47,9 +46,9 @@ public class WorkspaceFolderResourcesImpl extends AbstractResources implements W
 
     /**
      * List folders of a given workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /workspace/{id}/folders
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -75,9 +74,9 @@ public class WorkspaceFolderResourcesImpl extends AbstractResources implements W
 
     /**
      * Create a folder in the workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /workspace/{id}/folders
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if folder is null
      *   - InvalidRequestException : if there is any problem with the REST API request

--- a/src/main/java/com/smartsheet/api/internal/WorkspaceResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/WorkspaceResourcesImpl.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.ShareResources;
 import com.smartsheet.api.SmartsheetException;
@@ -41,27 +40,29 @@ import java.util.Map;
 
 /**
  * This is the implementation of the WorkspaceResources.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
  */
 public class WorkspaceResourcesImpl extends AbstractResources implements WorkspaceResources {
+    private static final String WORKSPACES = "workspaces";
+
     /**
      * Represents the WorkspaceFolderResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private WorkspaceFolderResources folders;
 
     /**
      * Represents the ShareResources.
-     *
+     * <p>
      * It will be initialized in constructor and will not change afterwards.
      */
     private ShareResources shares;
 
     /**
      * Constructor.
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if any argument is
      *
@@ -69,25 +70,20 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
      */
     public WorkspaceResourcesImpl(SmartsheetImpl smartsheet) {
         super(smartsheet);
-        this.shares = new ShareResourcesImpl(smartsheet, "workspaces");
+        this.shares = new ShareResourcesImpl(smartsheet, WORKSPACES);
         this.folders = new WorkspaceFolderResourcesImpl(smartsheet);
     }
 
     /**
      * List all workspaces.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /workspaces
-     *
+     * <p>
      * Exceptions:
-     *
      *   - InvalidRequestException : if there is any problem with the REST API request
-     *
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
-     *
      *   - ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
-     *
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
-     *
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
      * @param parameters the object containing the pagination parameters
@@ -95,7 +91,7 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
      * @throws SmartsheetException the smartsheet exception
      */
     public PagedResult<Workspace> listWorkspaces(PaginationParameters parameters) throws SmartsheetException {
-        String path = "workspaces";
+        String path = WORKSPACES;
 
         if (parameters != null) {
             path += parameters.toQueryString();
@@ -105,32 +101,26 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
 
     /**
      * Get a workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: GET /workspace/{id}
-     *
+     * <p>
      * Exceptions:
-     *
      *   - InvalidRequestException : if there is any problem with the REST API request
-     *
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
-     *
      *   - ResourceNotFoundException : if the resource can not be found
-     *
      *   - ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
-     *
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
-     *
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
      * @param id the id
      * @param loadAll load all contents in a workspace
      * @param includes used to specify the optional objects to include
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Workspace getWorkspace(long id, Boolean loadAll, EnumSet<SourceInclusion> includes) throws SmartsheetException {
-        String path = "workspaces/" + id;
+        String path = WORKSPACES + "/" + id;
 
         // Add the parameters to a map and build the query string at the end
         Map<String, Object> parameters = new HashMap<>();
@@ -147,21 +137,15 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
 
     /**
      * Create a workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /workspaces
-     *
+     * <p>
      * Exceptions:
-     *
      *   - IllegalArgumentException : if any argument is null
-     *
      *   - InvalidRequestException : if there is any problem with the REST API request
-     *
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
-     *
      *   - ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
-     *
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
-     *
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
      * @param workspace the workspace to create, limited to the following required attributes: * name (string)
@@ -169,44 +153,37 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
      * @throws SmartsheetException the smartsheet exception
      */
     public Workspace createWorkspace(Workspace workspace) throws SmartsheetException {
-        return this.createResource("workspaces", Workspace.class, workspace);
+        return this.createResource(WORKSPACES, Workspace.class, workspace);
     }
 
     /**
      * Update a workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: PUT /workspace/{id}
-     *
+     * <p>
      * Exceptions:
-     *
      *   - IllegalArgumentException : if any argument is null
-     *
      *   - InvalidRequestException : if there is any problem with the REST API request
-     *
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
-     *
      *   - ResourceNotFoundException : if the resource can not be found
-     *
      *   - ServiceUnavailableException : if the REST API service is not available (possibly due to rate limiting)
-     *
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
-     *
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
      * @param workspace the workspace to update limited to the following attribute: * name (string)
      * @return the updated workspace (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     public Workspace updateWorkspace(Workspace workspace) throws SmartsheetException {
-        return this.updateResource("workspaces/" + workspace.getId(), Workspace.class, workspace);
+        return this.updateResource(WORKSPACES + "/" + workspace.getId(), Workspace.class, workspace);
     }
 
     /**
      * Delete a workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: DELETE /workspace{id}
-     *
+     * <p>
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -219,14 +196,14 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
      * @throws SmartsheetException the smartsheet exception
      */
     public void deleteWorkspace(long id) throws SmartsheetException {
-        this.deleteResource("workspaces/" + id, Workspace.class);
+        this.deleteResource(WORKSPACES + "/" + id, Workspace.class);
     }
 
     /**
      * Creates a copy of the specified workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /workspaces/{workspaceId}/copy
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -242,15 +219,20 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
      * @return the folder
      * @throws SmartsheetException the smartsheet exception
      */
-    public Workspace copyWorkspace(long workspaceId, ContainerDestination containerDestination, EnumSet<WorkspaceCopyInclusion> includes, EnumSet<WorkspaceRemapExclusion> skipRemap) throws SmartsheetException {
+    public Workspace copyWorkspace(
+            long workspaceId,
+            ContainerDestination containerDestination,
+            EnumSet<WorkspaceCopyInclusion> includes,
+            EnumSet<WorkspaceRemapExclusion> skipRemap
+    ) throws SmartsheetException {
         return copyWorkspace(workspaceId, containerDestination, includes, skipRemap, null);
     }
 
     /**
      * Creates a copy of the specified workspace.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /workspaces/{workspaceId}/copy
-     *
+     * <p>
      * Exceptions:
      *   IllegalArgumentException : if folder is null
      *   InvalidRequestException : if there is any problem with the REST API request
@@ -270,7 +252,7 @@ public class WorkspaceResourcesImpl extends AbstractResources implements Workspa
     public Workspace copyWorkspace(long workspaceId, ContainerDestination containerDestination, EnumSet<WorkspaceCopyInclusion> includes,
                                    EnumSet<WorkspaceRemapExclusion> skipRemap, EnumSet<CopyExclusion> excludes) throws SmartsheetException {
 
-        String path = "workspaces/" + workspaceId + "/copy";
+        String path = WORKSPACES + "/" + workspaceId + "/copy";
         Map<String, Object> parameters = new HashMap<>();
 
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));


### PR DESCRIPTION
Fixes the violations of the `Impl` classes in the `com.smartsheet.api.internal` path

I will work package by package until we don't have anymore checkstyle violations. 

This MR will take us from `2400` violations to `1947` violations.