### PR TITLE
Fix remaining Checkstyle violations and Enable Checkstyle

### DIFF
--- a/.github/workflows/test-mainline.yaml
+++ b/.github/workflows/test-mainline.yaml
@@ -20,4 +20,4 @@ jobs:
         env:
           SMARTSHEET_ACCESS_TOKEN: ${{secrets.SMARTSHEET_ACCESS_TOKEN}}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew clean test jacocoTestReport coveralls
+        run: ./gradlew clean build jacocoTestReport coveralls

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Run Unit Tests
         env:
           SMARTSHEET_ACCESS_TOKEN: ${{secrets.SMARTSHEET_ACCESS_TOKEN}}
-        run: ./gradlew clean test jacocoTestReport
+        run: ./gradlew clean build jacocoTestReport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased - 
 ### Added
 - Added latest Checkstyle version, 
-  - for violations in `src/main/` the build WILL NOT fail since we haven't fixed all the existing violations  
-  - for violations in `src/test/` the build WILL fail since we fixed all the existing violations  
+  - for violations in `src/main/` the build WILL fail if we exceed 20 violations since we haven't fixed all existing ones yet  
+  - for violations in `src/test/` the build WILL fail if there is a single violation  
 
 ## [3.1.2] - 2023-07-25
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,15 @@ plugins {
 }
 
 // Project Settings
+// =============================================
+// The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
+// The version. This will be added to the end of the Jar and all other resources that are created during the build.
 version = '3.1.2'
+// The Java version:
 sourceCompatibility = '11'
 
-// Variables to expose
+// Variables to expose. This is mainly for having a convenient place to store/view dependency versions.
 ext {
     assertJVersion = '3.24.2'
     checkstyleVersion = '10.12.1'
@@ -58,12 +62,12 @@ ext {
     slf4jVersion = '1.7.25'
 }
 
-// Tell Gradle where to pull dependencies from
+// Tell Gradle where to download dependencies from
 repositories {
     mavenCentral()
 }
 
-// Libraries we need to import
+// Libraries we need to import to build/test our code
 dependencies {
     // Compile dependencies (dependencies needed to run the lib)
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}"
@@ -83,10 +87,12 @@ dependencies {
     testImplementation "org.slf4j:slf4j-simple:${slf4jSimpleVersion}"
 }
 
+// Configuration for our Javadocs
 javadoc {
     source = sourceSets.main.allJava
 }
 
+// Task to run the SDK tests
 tasks.register('sdkTest', Test) {
     // Discover and execute JUnit Platform-based tests
     useJUnitPlatform()
@@ -157,7 +163,9 @@ jacocoTestReport {
 
 // Configuration for the extra Jars we would like to produce
 java {
+    // Produce a Javadoc Jar so people can understand what our code does
     withJavadocJar()
+    // Produce a Sources Jar so people that use our library can analyze our code
     withSourcesJar()
 }
 
@@ -213,8 +221,7 @@ nexusPublishing {
     }
 }
 
-
-// Configuration for how we want to sign our Jar files
+// Configuration for how we want to sign our Jar files. This is how Maven Central will know we are who we say we are when publishing.
 signing {
     // We will have the gpg-agent on the GitHub runner, so we want to use that key to sign
     // Link: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent
@@ -239,11 +246,11 @@ signing {
 checkstyle {
     toolVersion = "${checkstyleVersion}"
     configFile = file('config/checkstyle/checkstyle-custom.xml')
-    // If there is a checkstyle violation in our main code, then do not fail the build because we haven't fixed them all yet
-    ignoreFailures = true
 }
 
-// If there is a checkstyle violation in our tests, then fail the build
-checkstyleTest {
-    ignoreFailures = false
+// Override configuration for Checkstyle that runs on our 'src/main' package
+checkstyleMain {
+    // Since our main classes still have some outstanding checkstyle violations, we can allow up to 20 errors so we don't fail on the
+    // existing violations, but will fail if we add any new ones. We do not allow _any_ violations in test files.
+    maxErrors = 20
 }

--- a/src/main/java/com/smartsheet/api/AccessTokenExpiredException.java
+++ b/src/main/java/com/smartsheet/api/AccessTokenExpiredException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.Error;
 

--- a/src/main/java/com/smartsheet/api/AssociatedDiscussionResources.java
+++ b/src/main/java/com/smartsheet/api/AssociatedDiscussionResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.Discussion;
 
@@ -30,11 +28,11 @@ import com.smartsheet.api.models.Discussion;
 @Deprecated
 public interface AssociatedDiscussionResources {
     /**
-     * @deprecated As of release 2.0
      * @param objectId the object id (sheet id or row id)
      * @param discussion the discussion object
      * @return the created discussion
      * @throws SmartsheetException if there is any other error during the operation
+     * @deprecated As of release 2.0
      */
     @Deprecated
     Discussion createDiscussion(long objectId, Discussion discussion) throws SmartsheetException;

--- a/src/main/java/com/smartsheet/api/AttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/AttachmentResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,41 +20,40 @@ package com.smartsheet.api;
  * %[license]
  */
 
-
 import com.smartsheet.api.models.Attachment;
 
 import java.io.File;
 import java.io.InputStream;
 
 /**
- * @deprecated As of release 2.0
  * <p>This interface provides methods to access Attachment resources by their id.</p>
  *
  * <p>Thread Safety: Implementation of this interface must be thread safe.</p>
+ * @deprecated As of release 2.0
  */
 @Deprecated
 public interface AttachmentResources {
 
     /**
-     * @deprecated As of release 2.0
      * @param attachmentId the id
      * @param file the file
      * @param contentType the content type
      * @return the attachment (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
+     * @deprecated As of release 2.0
      */
     @Deprecated
     Attachment attachNewVersion(long attachmentId, File file, String contentType);
 
     /**
-     * @deprecated As of release 2.0
      * @param attachmentId the id of the attachment to upload a new version.
      * @param inputStream the file to attach
      * @param contentType the content type of the file
      * @param attachmentName attachment name
      * @param contentLength content length
      * @return the created attachment
+     * @deprecated As of release 2.0
      */
     @Deprecated
-    Attachment attachNewVersion (long attachmentId, InputStream inputStream, String contentType, long contentLength, String attachmentName);
+    Attachment attachNewVersion(long attachmentId, InputStream inputStream, String contentType, long contentLength, String attachmentName);
 }

--- a/src/main/java/com/smartsheet/api/AttachmentVersioningResources.java
+++ b/src/main/java/com/smartsheet/api/AttachmentVersioningResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,7 +58,7 @@ public interface AttachmentVersioningResources {
      * @param attachmentId the attachment id
      * @param parameters the pagination paramaters
      * @return the attachment (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -85,5 +86,10 @@ public interface AttachmentVersioningResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Attachment attachNewVersion(long sheetId ,long attachmentId, File file, String contentType) throws FileNotFoundException, SmartsheetException;
+    Attachment attachNewVersion(
+            long sheetId,
+            long attachmentId,
+            File file,
+            String contentType
+    ) throws FileNotFoundException, SmartsheetException;
 }

--- a/src/main/java/com/smartsheet/api/AuthorizationException.java
+++ b/src/main/java/com/smartsheet/api/AuthorizationException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.Error;
 

--- a/src/main/java/com/smartsheet/api/ColumnResources.java
+++ b/src/main/java/com/smartsheet/api/ColumnResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,32 +20,30 @@ package com.smartsheet.api;
  * %[license]
  */
 
-
-
 import com.smartsheet.api.models.Column;
 
 /**
- * @deprecated As of release 2.0
  * <p>This interface provides methods to access Column resources.</p>
  *
  * <p>Thread Safety: Implementation of this interface must be thread safe.</p>
+ * @deprecated As of release 2.0
  */
 @Deprecated
 public interface ColumnResources {
 
     /**
-     * @deprecated As of release 2.0
      * @param column the column to update
      * @return the updated Column (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
+     * @deprecated As of release 2.0
      */
     @Deprecated
-    Column updateColumn(Column column) ;
+    Column updateColumn(Column column);
 
     /**
-     * @deprecated As of release 2.0
      * @param id id of the column
      * @param sheetId the sheet id
+     * @deprecated As of release 2.0
      */
     @Deprecated
     void deleteColumn(long id, long sheetId);

--- a/src/main/java/com/smartsheet/api/CommentAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/CommentAttachmentResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -84,26 +85,13 @@ public interface CommentAttachmentResources {
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    Attachment attachFile(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
+    Attachment attachFile(
+            long sheetId,
+            long commentId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) throws SmartsheetException;
 
-//    /**
-//     * <p>Attach a file to a comment with multipart upload.</p>
-//     *
-//     * <p>It mirrors to the following Smartsheet REST API method:</p>
-//     *<p>POST /sheets/{sheetId}/comments/{commentId}/attachments</p>
-//     *
-//     * @param sheetId the id of the sheet
-//     * @param comment the comment object to be added
-//     * @param file the file to attach
-//     * @param contentType the content type of the file
-//     * @return the created attachment
-//     * @throws FileNotFoundException the file not found exception
-//     * @throws IllegalArgumentException if any argument is null or empty string
-//     * @throws InvalidRequestException if there is any problem with the REST API request
-//     * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
-//     * @throws ResourceNotFoundException if the resource cannot be found
-//     * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
-//     * @throws SmartsheetException if there is any other error during the operation
-//     */
-//    Attachment attachFileWithMultipartUpload(long sheetId, Comment comment, File file, String contentType) throws FileNotFoundException, SmartsheetException;
-    }
+}

--- a/src/main/java/com/smartsheet/api/CommentResources.java
+++ b/src/main/java/com/smartsheet/api/CommentResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Comment;
 
@@ -29,26 +28,26 @@ import com.smartsheet.api.models.Comment;
 @Deprecated
 public interface CommentResources {
     /**
-     * @deprecated As of release 2.0
      * @param sheetId the id
      * @param commentId the commentid
      * @return the comment (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
+     * @deprecated As of release 2.0
      */
     @Deprecated
-    Comment getComment(long sheetId, long commentId) ;
+    Comment getComment(long sheetId, long commentId);
 
     /**
-     * @deprecated As of release 2.0
      * @param sheetId the id
      * @param commentId the commentid
+     * @deprecated As of release 2.0
      */
     @Deprecated
     void deleteComment(long sheetId, long commentId);
 
     /**
-     * @deprecated As of release 2.0
      * @return associated resources
+     * @deprecated As of release 2.0
      */
     @Deprecated
     AssociatedAttachmentResources attachments();

--- a/src/main/java/com/smartsheet/api/ContactResources.java
+++ b/src/main/java/com/smartsheet/api/ContactResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/DiscussionAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/DiscussionAttachmentResources.java
@@ -13,9 +13,9 @@ import com.smartsheet.api.models.PaginationParameters;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,7 @@ public interface DiscussionAttachmentResources {
      * @param discussionId the discussion id
      * @param parameters the pagination parameters
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     PagedResult<Attachment> getAttachments(long sheetId, long discussionId, PaginationParameters parameters) throws SmartsheetException;

--- a/src/main/java/com/smartsheet/api/DiscussionCommentResources.java
+++ b/src/main/java/com/smartsheet/api/DiscussionCommentResources.java
@@ -14,9 +14,9 @@ import java.io.IOException;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,7 +63,13 @@ public interface DiscussionCommentResources {
      * @throws SmartsheetException if there is any other error during the operation
      * @throws IOException is there is any error with file
      */
-    Comment addCommentWithAttachment(long sheetId, long discussionId, Comment comment, File file, String contentType) throws SmartsheetException, IOException;
+    Comment addCommentWithAttachment(
+            long sheetId,
+            long discussionId,
+            Comment comment,
+            File file,
+            String contentType
+    ) throws SmartsheetException, IOException;
 
     /**
      * <p>Update the specified comment</p>

--- a/src/main/java/com/smartsheet/api/DiscussionResources.java
+++ b/src/main/java/com/smartsheet/api/DiscussionResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Comment;
 
@@ -48,8 +47,8 @@ public interface DiscussionResources {
     Comment addDiscussionComment(long id, Comment comment) throws SmartsheetException;
 
     /**
-     * @deprecated As of release 2.0
      * @return associated resources
+     * @deprecated As of release 2.0
      */
     @Deprecated
     AssociatedAttachmentResources attachments();

--- a/src/main/java/com/smartsheet/api/EventResources.java
+++ b/src/main/java/com/smartsheet/api/EventResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,33 +20,31 @@ package com.smartsheet.api;
  * %[license]
  */
 
-
 import com.smartsheet.api.models.EventResult;
 
 public interface EventResources {
 
-        /**
-         * <p>List all events.</p>
-         *
-         * <p>It mirrors to the following Smartsheet REST API method: GET /events</p>
-         *
-         * @param since Starting time for events to return. You must pass in a value for either since or
-         *              streamPosition and never both.
-         * @param streamPosition Indicates next set of events to return. Use value of nextStreamPosition returned
-         *                       from the previous call. You must pass in a value for either since or streamPosition
-         *                       and never both.
-         * @param maxCount Maximum number of events to return as response to this call. Must be between
-         *                 1 through 10,000 (inclusive).
-         * @param numericDates If true, dates are accepted and returned in Unix epoch time (milliseconds since midnight
-         *                     on January 1, 1970 in UTC time). Default is false, which means ISO-8601 format
-         * @return A list of all events (note that an empty list will be returned if there are none).
-         * @throws IllegalArgumentException if any argument is null or empty string
-         * @throws InvalidRequestException if there is any problem with the REST API request
-         * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
-         * @throws ResourceNotFoundException if the resource cannot be found
-         * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
-         * @throws SmartsheetException if there is any other error during the operation
-         */
-        EventResult listEvents(Object since, String streamPosition, Integer maxCount,
-                                      Boolean numericDates) throws SmartsheetException;
+    /**
+     * <p>List all events.</p>
+     *
+     * <p>It mirrors to the following Smartsheet REST API method: GET /events</p>
+     *
+     * @param since Starting time for events to return. You must pass in a value for either since or
+     *              streamPosition and never both.
+     * @param streamPosition Indicates next set of events to return. Use value of nextStreamPosition returned
+     *                       from the previous call. You must pass in a value for either since or streamPosition
+     *                       and never both.
+     * @param maxCount Maximum number of events to return as response to this call. Must be between
+     *                 1 through 10,000 (inclusive).
+     * @param numericDates If true, dates are accepted and returned in Unix epoch time (milliseconds since midnight
+     *                     on January 1, 1970 in UTC time). Default is false, which means ISO-8601 format
+     * @return A list of all events (note that an empty list will be returned if there are none).
+     * @throws IllegalArgumentException if any argument is null or empty string
+     * @throws InvalidRequestException if there is any problem with the REST API request
+     * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
+     * @throws ResourceNotFoundException if the resource cannot be found
+     * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
+     * @throws SmartsheetException if there is any other error during the operation
+     */
+    EventResult listEvents(Object since, String streamPosition, Integer maxCount, Boolean numericDates) throws SmartsheetException;
 }

--- a/src/main/java/com/smartsheet/api/FavoriteResources.java
+++ b/src/main/java/com/smartsheet/api/FavoriteResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 
 public interface FavoriteResources {
-
     /**
      * <p>Adds one or more items to the user’s list of Favorite items.</p>
      *
@@ -44,12 +43,11 @@ public interface FavoriteResources {
      *   SmartsheetRestException : if there is any other REST API related error occurred during the operation
      *   SmartsheetException : if there is any other error occurred during the operation
      *
-     * @param favorites the list of favorites object limited to the following attributes: *
-     * objectId * type
+     * @param favorites the list of favorites object limited to the following attributes: * objectId * type
      * @return a single Favorite object or an array of Favorite objects
      * @throws SmartsheetException the smartsheet exception
      */
-     List<Favorite> addFavorites(List<Favorite> favorites) throws SmartsheetException;
+    List<Favorite> addFavorites(List<Favorite> favorites) throws SmartsheetException;
 
     /**
      * <p>Gets a list of all of the user’s Favorite items.</p>

--- a/src/main/java/com/smartsheet/api/FolderResources.java
+++ b/src/main/java/com/smartsheet/api/FolderResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.ContainerDestination;
 import com.smartsheet.api.models.Folder;
@@ -47,7 +46,7 @@ public interface FolderResources {
      * @param folderId the folder id
      * @param includes the include parameters
      * @return the folder (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -62,7 +61,7 @@ public interface FolderResources {
      *
      * @param folder the folder to update
      * @return the updated folder (note that if there is no such folder, this method will throw Resource Not Found
-     * Exception rather than returning null).
+     *     Exception rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -141,7 +140,12 @@ public interface FolderResources {
      * @return the folder
      * @throws SmartsheetException the smartsheet exception
      */
-    Folder copyFolder(long folderId, ContainerDestination containerDestination, EnumSet<FolderCopyInclusion> includes, EnumSet<FolderRemapExclusion> skipRemap) throws SmartsheetException;
+    Folder copyFolder(
+            long folderId,
+            ContainerDestination containerDestination,
+            EnumSet<FolderCopyInclusion> includes,
+            EnumSet<FolderRemapExclusion> skipRemap
+    ) throws SmartsheetException;
 
     /**
      * <p>Creates a copy of the specified Folder.</p>

--- a/src/main/java/com/smartsheet/api/GroupMemberResources.java
+++ b/src/main/java/com/smartsheet/api/GroupMemberResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.GroupMember;
 

--- a/src/main/java/com/smartsheet/api/GroupResources.java
+++ b/src/main/java/com/smartsheet/api/GroupResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Group;
 import com.smartsheet.api.models.PagedResult;
@@ -38,7 +37,8 @@ public interface GroupResources {
      * <p>It mirrors to the following Smartsheet REST API method: GET /groups</p>
      *
      * @param parameters the paging parameters object
-     * @return A list of all {@link Group}s. Note that the groups do not contain the membership details. You must get each group individually for group memebership.
+     * @return A list of all {@link Group}s. Note that the groups do not contain the membership details. You must get each group
+     *     individually for group membership.
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -48,14 +48,14 @@ public interface GroupResources {
      */
     PagedResult<Group> listGroups(PaginationParameters parameters) throws SmartsheetException;
 
-
     /**
      * <p>Get a {@link Group}.</p>
      *
      * <p>It mirrors to the following Smartsheet REST API method: GET /group/{id}</p>
      *
      * @param groupId the {@link Group} id
-     * @return the {@link Group} (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null)
+     * @return the {@link Group} (note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/HomeFolderResources.java
+++ b/src/main/java/com/smartsheet/api/HomeFolderResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Folder;
 import com.smartsheet.api.models.PagedResult;

--- a/src/main/java/com/smartsheet/api/HomeResources.java
+++ b/src/main/java/com/smartsheet/api/HomeResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Home;
 import com.smartsheet.api.models.enums.SourceExclusion;
@@ -42,7 +41,7 @@ public interface HomeResources {
      *
      * @param includes used to specify the optional objects to include.
      * @return the home resource (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -61,7 +60,7 @@ public interface HomeResources {
      * @param includes used to specify the optional objects to include.
      * @param excludes  used to specify the optional objects to exclude.
      * @return the home resource (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/ImageUrlResources.java
+++ b/src/main/java/com/smartsheet/api/ImageUrlResources.java
@@ -1,3 +1,5 @@
+package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -7,9 +9,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +19,6 @@
  * limitations under the License.
  * %[license]
  */
-package com.smartsheet.api;
 
 import com.smartsheet.api.models.ImageUrl;
 import com.smartsheet.api.models.ImageUrlMap;
@@ -32,7 +33,7 @@ public interface ImageUrlResources {
      *
      * @param requestUrls array of requested Images and sizes.
      * @return the ImageUrlMap object (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/InvalidRequestException.java
+++ b/src/main/java/com/smartsheet/api/InvalidRequestException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.Error;
 

--- a/src/main/java/com/smartsheet/api/PassthroughResources.java
+++ b/src/main/java/com/smartsheet/api/PassthroughResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,7 +74,7 @@ public interface PassthroughResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    String putRequest(String endpoint, String payload,  Map<String, Object> parameters) throws SmartsheetException;
+    String putRequest(String endpoint, String payload, Map<String, Object> parameters) throws SmartsheetException;
 
     /**
      * <p>Issue an HTTP DELETE request.</p>

--- a/src/main/java/com/smartsheet/api/ReportResources.java
+++ b/src/main/java/com/smartsheet/api/ReportResources.java
@@ -1,6 +1,5 @@
 package com.smartsheet.api;
 
-
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -10,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +48,7 @@ public interface ReportResources {
      * @param pageSize page size parameter for pagination
      * @param page page parameter for pagination
      * @return  the report (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -57,7 +56,7 @@ public interface ReportResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-     Report getReport(long reportId, EnumSet<ReportInclusion> includes, Integer pageSize, Integer page) throws SmartsheetException;
+    Report getReport(long reportId, EnumSet<ReportInclusion> includes, Integer pageSize, Integer page) throws SmartsheetException;
 
     /**
      * <p>Get a report.</p>
@@ -70,7 +69,7 @@ public interface ReportResources {
      * @param page page parameter for pagination
      * @param level compatibility level
      * @return  the report (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -78,7 +77,13 @@ public interface ReportResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Report getReport(long reportId, EnumSet<ReportInclusion> includes, Integer pageSize, Integer page, Integer level) throws SmartsheetException;
+    Report getReport(
+            long reportId,
+            EnumSet<ReportInclusion> includes,
+            Integer pageSize,
+            Integer page,
+            Integer level
+    ) throws SmartsheetException;
 
     /**
      * <p>Send a sheet as a PDF attachment via Email To the designated recipients.</p>
@@ -94,7 +99,7 @@ public interface ReportResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-     void sendReport(long reportId, SheetEmail email) throws SmartsheetException;
+    void sendReport(long reportId, SheetEmail email) throws SmartsheetException;
 
     /**
      * <p>List all reports.</p>
@@ -113,7 +118,7 @@ public interface ReportResources {
      * @return all sheets (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
-     PagedResult<Report> listReports(PaginationParameters parameters, Date modifiedSince) throws SmartsheetException;
+    PagedResult<Report> listReports(PaginationParameters parameters, Date modifiedSince) throws SmartsheetException;
 
     /**
      * <p>List all reports.</p>
@@ -131,8 +136,8 @@ public interface ReportResources {
      * @return all sheets (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
-     @Deprecated
-     PagedResult<Report> listReports(PaginationParameters parameters) throws SmartsheetException;
+    @Deprecated
+    PagedResult<Report> listReports(PaginationParameters parameters) throws SmartsheetException;
 
     /**
      * <p>Get a Report as an excel file.</p>

--- a/src/main/java/com/smartsheet/api/ResourceNotFoundException.java
+++ b/src/main/java/com/smartsheet/api/ResourceNotFoundException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.Error;
 

--- a/src/main/java/com/smartsheet/api/RowAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/RowAttachmentResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,7 +33,7 @@ import java.io.InputStream;
  *
  * <p>Thread Safety: Implementation of this interface must be thread safe.</p>
  */
-public interface RowAttachmentResources{
+public interface RowAttachmentResources {
 
     /**
      * <p>Attach a URL to a comment.</p>
@@ -73,7 +73,7 @@ public interface RowAttachmentResources{
      * @param rowId the row id
      * @param parameters the pagination parameters
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     PagedResult<Attachment> getAttachments(long sheetId, long rowId, PaginationParameters parameters) throws SmartsheetException;
@@ -110,5 +110,12 @@ public interface RowAttachmentResources{
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    Attachment attachFile(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
+    Attachment attachFile(
+            long sheetId,
+            long rowId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) throws SmartsheetException;
 }

--- a/src/main/java/com/smartsheet/api/RowColumnResources.java
+++ b/src/main/java/com/smartsheet/api/RowColumnResources.java
@@ -32,7 +32,7 @@ import java.util.EnumSet;
 
 /**
  * This interface provides methods to access row column resources that are associated to a sheet object.
- *
+ * <p>
  * Thread Safety: Implementation of this interface must be thread safe.
  */
 public interface RowColumnResources {
@@ -54,10 +54,15 @@ public interface RowColumnResources {
      * @param columnId the column id
      * @param pagination the pagination parameters
      * @return the modification history (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
-    PagedResult<CellHistory> getCellHistory(long sheetId, long rowId, long columnId, PaginationParameters pagination) throws SmartsheetException;
+    PagedResult<CellHistory> getCellHistory(
+            long sheetId,
+            long rowId,
+            long columnId,
+            PaginationParameters pagination
+    ) throws SmartsheetException;
 
     /**
      * <p>Get the cell modification history.</p>
@@ -79,7 +84,7 @@ public interface RowColumnResources {
      * @param includes cell history inclusion
      * @param level compatbility level
      * @return the modification history (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     PagedResult<CellHistory> getCellHistory(long sheetId, long rowId, long columnId, PaginationParameters pagination,
@@ -103,11 +108,16 @@ public interface RowColumnResources {
      * @param columnId the column id
      * @param file the file path
      * @param contentType MIME type
-     * ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      * @throws FileNotFoundException image file not found
      */
-    void addImageToCell(long sheetId, long rowId, long columnId, String file, String contentType) throws FileNotFoundException, SmartsheetException;
+    void addImageToCell(
+            long sheetId,
+            long rowId,
+            long columnId,
+            String file,
+            String contentType
+    ) throws FileNotFoundException, SmartsheetException;
 
     /**
      * <p>Uploads an image to the specified cell within a sheet.</p>
@@ -129,17 +139,24 @@ public interface RowColumnResources {
      * @param contentType MIME type
      * @param overrideValidation override column type validation
      * @param altText alternate description for the image
-     * ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      * @throws FileNotFoundException image file not found
      */
-    void addImageToCell(long sheetId, long rowId, long columnId, String file, String contentType, boolean overrideValidation, String altText) throws FileNotFoundException, SmartsheetException;
+    void addImageToCell(
+            long sheetId,
+            long rowId,
+            long columnId,
+            String file,
+            String contentType,
+            boolean overrideValidation,
+            String altText
+    ) throws FileNotFoundException, SmartsheetException;
 
     /**
      * Add an image to a cell.
-     *
+     * <p>
      * It mirrors the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/cellimages
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -163,9 +180,9 @@ public interface RowColumnResources {
 
     /**
      * Add an image to a cell.
-     *
+     * <p>
      * It mirrors the following Smartsheet REST API method: POST /sheets/{sheetId}/rows/{rowId}/columns/{columnId}/cellimages
-     *
+     * <p>
      * Exceptions:
      *   InvalidRequestException : if there is any problem with the REST API request
      *   AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -184,6 +201,14 @@ public interface RowColumnResources {
      * @param altText alternate description for the image
      * @throws SmartsheetException the smartsheet exception
      */
-    void addImageToCell(long sheetId, long rowId, long columnId, InputStream inputStream, String contentType,
-                               long contentLength, boolean overrideValidation, String altText) throws SmartsheetException;
+    void addImageToCell(
+            long sheetId,
+            long rowId,
+            long columnId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            boolean overrideValidation,
+            String altText
+    ) throws SmartsheetException;
 }

--- a/src/main/java/com/smartsheet/api/RowDiscussionResources.java
+++ b/src/main/java/com/smartsheet/api/RowDiscussionResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -76,7 +77,12 @@ public interface RowDiscussionResources {
      * @return the row discussions
      * @throws SmartsheetException the smartsheet exception
      */
-    PagedResult<Discussion> listDiscussions(long sheetId, long rowId, PaginationParameters pagination, EnumSet<DiscussionInclusion> includes) throws SmartsheetException;
+    PagedResult<Discussion> listDiscussions(
+            long sheetId,
+            long rowId,
+            PaginationParameters pagination,
+            EnumSet<DiscussionInclusion> includes
+    ) throws SmartsheetException;
 
     /**
      * <p>Create discussion on a row.</p>
@@ -100,5 +106,11 @@ public interface RowDiscussionResources {
      * @throws SmartsheetException the smartsheet exception
      * @throws IOException is there is an I/O exception
      */
-    Discussion createDiscussionWithAttachment(long sheetId, long rowId, Discussion discussion, File file, String contentType) throws SmartsheetException, IOException;
+    Discussion createDiscussionWithAttachment(
+            long sheetId,
+            long rowId,
+            Discussion discussion,
+            File file,
+            String contentType
+    ) throws SmartsheetException, IOException;
 }

--- a/src/main/java/com/smartsheet/api/RowResources.java
+++ b/src/main/java/com/smartsheet/api/RowResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Cell;
 import com.smartsheet.api.models.CellHistory;
@@ -46,7 +45,7 @@ public interface RowResources {
      * @param id the id
      * @param includes used to specify the optional objects to include.
      * @return the row resource (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -129,7 +128,7 @@ public interface RowResources {
      * @param rowId the row id
      * @param columnId the column id
      * @return the cell modification history (note that if there is no such resource, this method will throw
-     * ResourceeNotFoundException rather than returning null).
+     *     ResourceeNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/SearchResources.java
+++ b/src/main/java/com/smartsheet/api/SearchResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.SearchResult;
 import com.smartsheet.api.models.enums.SearchInclusion;
@@ -31,7 +30,7 @@ import java.util.EnumSet;
 
 /**
  * This interface provides methods to access search resources.
- *
+ * <p>
  * Thread Safety: Implementation of this interface must be thread safe.
  */
 public interface SearchResources {
@@ -43,7 +42,7 @@ public interface SearchResources {
      *
      * @param query the query text
      * @return the search result (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -65,7 +64,7 @@ public interface SearchResources {
      * @param modifiedSince only return items modified since this date
      * @param scopes enum set of search filters
      * @return the search result (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -73,7 +72,13 @@ public interface SearchResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    SearchResult search(String query, EnumSet<SearchInclusion> includes, SearchLocation location, Date modifiedSince, EnumSet<SearchScope> scopes) throws SmartsheetException;
+    SearchResult search(
+            String query,
+            EnumSet<SearchInclusion> includes,
+            SearchLocation location,
+            Date modifiedSince,
+            EnumSet<SearchScope> scopes
+    ) throws SmartsheetException;
 
     /**
      * <p>Performs a search within a sheet.</p>
@@ -83,7 +88,7 @@ public interface SearchResources {
      * @param sheetId the sheet id
      * @param query the query text
      * @return the search result (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/ServerInfoResources.java
+++ b/src/main/java/com/smartsheet/api/ServerInfoResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +23,7 @@ import com.smartsheet.api.models.ServerInfo;
 
 /**
  * This interface provides methods to server information resources.
- *
+ * <p>
  * Thread Safety: Implementation of this interface must be thread safe.
  */
 public interface ServerInfoResources {

--- a/src/main/java/com/smartsheet/api/ServiceUnavailableException.java
+++ b/src/main/java/com/smartsheet/api/ServiceUnavailableException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.Error;
 

--- a/src/main/java/com/smartsheet/api/ShareResources.java
+++ b/src/main/java/com/smartsheet/api/ShareResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
@@ -72,7 +71,11 @@ public interface ShareResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    PagedResult<Share> listShares(long objectId, PaginationParameters parameters, Boolean includeWorkspaceShares) throws SmartsheetException;
+    PagedResult<Share> listShares(
+            long objectId,
+            PaginationParameters parameters,
+            Boolean includeWorkspaceShares
+    ) throws SmartsheetException;
 
     /**
      * <p>Get a Share.</p>
@@ -93,7 +96,7 @@ public interface ShareResources {
      * @param objectId the ID of the object to share
      * @param shareId the ID of the share
      * @return the share (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     Share getShare(long objectId, String shareId) throws SmartsheetException;
@@ -134,7 +137,7 @@ public interface ShareResources {
      * @param objectId the ID of the object to share
      * @param share the share
      * @return the updated share (note that if there is no such resource, this method will throw
-     *  ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/SheetAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/SheetAttachmentResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,7 +84,7 @@ public interface SheetAttachmentResources {
      * @param sheetId the sheet id
      * @param attachmentId the attachment id
      * @return the resource (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     Attachment getAttachment(long sheetId, long attachmentId) throws SmartsheetException;
@@ -138,7 +139,13 @@ public interface SheetAttachmentResources {
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    Attachment attachFile(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
+    Attachment attachFile(
+            long sheetId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String attachmentName
+    ) throws SmartsheetException;
 
     /**
      * <p>Creates an object of AttachmentVersioningResources for access to versioning through SheetAttachmentResources.</p>

--- a/src/main/java/com/smartsheet/api/SheetAutomationRuleResources.java
+++ b/src/main/java/com/smartsheet/api/SheetAutomationRuleResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +53,7 @@ public interface SheetAutomationRuleResources {
      * @param sheetId the sheet id
      * @param automationRuleId the automation rule id
      * @return the automation rule (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -70,7 +71,7 @@ public interface SheetAutomationRuleResources {
      * @param sheetId the sheet id
      * @param automationRule the updated automation rule
      * @return the automation rule (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/SheetColumnResources.java
+++ b/src/main/java/com/smartsheet/api/SheetColumnResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Column;
 import com.smartsheet.api.models.PagedResult;
@@ -52,7 +51,11 @@ public interface SheetColumnResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    PagedResult<Column> listColumns(long sheetId, EnumSet<ColumnInclusion> includes, PaginationParameters pagination) throws SmartsheetException;
+    PagedResult<Column> listColumns(
+            long sheetId,
+            EnumSet<ColumnInclusion> includes,
+            PaginationParameters pagination
+    ) throws SmartsheetException;
 
     /**
      * <p>List columns of a given sheet.</p>
@@ -71,7 +74,12 @@ public interface SheetColumnResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    PagedResult<Column> listColumns(long sheetId, EnumSet<ColumnInclusion> includes, PaginationParameters pagination, Integer level) throws SmartsheetException;
+    PagedResult<Column> listColumns(
+            long sheetId,
+            EnumSet<ColumnInclusion> includes,
+            PaginationParameters pagination,
+            Integer level
+    ) throws SmartsheetException;
 
     /**
      * <p>Add column to a sheet.</p>
@@ -122,10 +130,10 @@ public interface SheetColumnResources {
      *
      * @param sheetId the sheetId
      * @param column the column to update limited to the following attributes: index (column's new index in the sheet),
-     * title, sheetId, type, options (optional), symbol (optional), systemColumnType (optional),
-     * autoNumberFormat (optional)
+     *     title, sheetId, type, options (optional), symbol (optional), systemColumnType (optional),
+     *     autoNumberFormat (optional)
      * @return the updated sheet (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws SmartsheetException the smartsheet exception
      */
     Column updateColumn(long sheetId, Column column) throws SmartsheetException;

--- a/src/main/java/com/smartsheet/api/SheetCommentResources.java
+++ b/src/main/java/com/smartsheet/api/SheetCommentResources.java
@@ -1,6 +1,5 @@
 package com.smartsheet.api;
 
-
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -10,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +21,7 @@ package com.smartsheet.api;
  */
 
 import com.smartsheet.api.models.Comment;
+
 /**
  * <p>This interface provides methods to access Sheet Comment resources.</p>
  *
@@ -36,7 +36,7 @@ public interface SheetCommentResources {
      * @param sheetId the ID of the sheet
      * @param commentId the ID of the comment
      * @return the comment (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws SmartsheetException if there is any other error during the operation
      */
     Comment getComment(long sheetId, long commentId) throws SmartsheetException;

--- a/src/main/java/com/smartsheet/api/SheetCrossSheetReferenceResources.java
+++ b/src/main/java/com/smartsheet/api/SheetCrossSheetReferenceResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -54,7 +54,7 @@ public interface SheetCrossSheetReferenceResources {
      * @param sheetId the sheet id
      * @param crossSheetReferenceId the cross sheet reference id
      * @return the cross sheet reference (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/SheetDiscussionResources.java
+++ b/src/main/java/com/smartsheet/api/SheetDiscussionResources.java
@@ -18,9 +18,9 @@ import java.util.EnumSet;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,7 +65,12 @@ public interface SheetDiscussionResources {
      * @throws SmartsheetException if there is any other error during the operation
      * @throws IOException is there is with file
      */
-    Discussion createDiscussionWithAttachment(long sheetId, Discussion discussion, File file, String contentType) throws SmartsheetException, IOException;
+    Discussion createDiscussionWithAttachment(
+            long sheetId,
+            Discussion discussion,
+            File file,
+            String contentType
+    ) throws SmartsheetException, IOException;
 
     /**
      * <p>Get a discussion.</p>
@@ -75,7 +80,7 @@ public interface SheetDiscussionResources {
      * @param discussionId the discussion id
      * @param sheetId the sheet id
      * @return the discussion (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -123,7 +128,11 @@ public interface SheetDiscussionResources {
      * @return a list of discussions
      * @throws SmartsheetException the smartsheet exception
      */
-    PagedResult<Discussion> listDiscussions(long sheetId, PaginationParameters pagination, EnumSet<DiscussionInclusion> includes) throws SmartsheetException;
+    PagedResult<Discussion> listDiscussions(
+            long sheetId,
+            PaginationParameters pagination,
+            EnumSet<DiscussionInclusion> includes
+    ) throws SmartsheetException;
 
     /**
      * <p>Creates an object of DiscussionCommentResources for access to discussion comments through SheetDiscussionResources.</p>

--- a/src/main/java/com/smartsheet/api/SheetFilterResources.java
+++ b/src/main/java/com/smartsheet/api/SheetFilterResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ public interface SheetFilterResources {
      * @param sheetId the sheet id
      * @param filterId the filter id
      * @return the sheet filter (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null).
+     *     rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/SheetResources.java
+++ b/src/main/java/com/smartsheet/api/SheetResources.java
@@ -391,7 +391,7 @@ public interface SheetResources {
      *
      * <p>It mirrors to the following Smartsheet REST API method: POST /folders/{folderId}/sheets/import</p>
      *
-     * @param folderID the folder id
+     * @param folderId the folder id
      * @param file path to the XLSX file
      * @param sheetName destination sheet name
      * @param headerRowIndex index (0 based) of row to be used for column names
@@ -405,7 +405,7 @@ public interface SheetResources {
      * @throws SmartsheetException if there is any other error during the operation
      */
     Sheet importXlsxInFolder(
-            long folderID,
+            long folderId,
             String file,
             String sheetName,
             Integer headerRowIndex,

--- a/src/main/java/com/smartsheet/api/SheetResources.java
+++ b/src/main/java/com/smartsheet/api/SheetResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.ContainerDestination;
 import com.smartsheet.api.models.MultiRowEmail;
@@ -66,7 +65,11 @@ public interface SheetResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    PagedResult<Sheet> listSheets(EnumSet<SourceInclusion> includes, PaginationParameters pagination, Date modifiedSince) throws SmartsheetException;
+    PagedResult<Sheet> listSheets(
+            EnumSet<SourceInclusion> includes,
+            PaginationParameters pagination,
+            Date modifiedSince
+    ) throws SmartsheetException;
 
     /**
      * <p>List all sheets.</p>
@@ -117,7 +120,7 @@ public interface SheetResources {
      * @param rowIds the row ids
      * @param rowNumbers the row numbers
      * @return the sheet resource (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -149,7 +152,7 @@ public interface SheetResources {
      * @param rowNumbers the row numbers
      * @param ifVersionAfter only fetch Sheet if more recent version available
      * @return the sheet resource (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -183,7 +186,7 @@ public interface SheetResources {
      * @param ifVersionAfter only fetch Sheet if more recent version available
      * @param level compatibility level
      * @return the sheet resource (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -375,7 +378,13 @@ public interface SheetResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Sheet importCsvInFolder(long folderID, String file, String sheetName, Integer headerRowIndex, Integer primaryColumnIndex) throws SmartsheetException;
+    Sheet importCsvInFolder(
+            long folderID,
+            String file,
+            String sheetName,
+            Integer headerRowIndex,
+            Integer primaryColumnIndex
+    ) throws SmartsheetException;
 
     /**
      * <p>Imports a sheet in given folder.</p>
@@ -395,7 +404,13 @@ public interface SheetResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Sheet importXlsxInFolder(long folderID, String file, String sheetName, Integer headerRowIndex, Integer primaryColumnIndex) throws SmartsheetException;
+    Sheet importXlsxInFolder(
+            long folderID,
+            String file,
+            String sheetName,
+            Integer headerRowIndex,
+            Integer primaryColumnIndex
+    ) throws SmartsheetException;
 
     /**
      * <p>Create a sheet in given workspace.</p>
@@ -430,7 +445,11 @@ public interface SheetResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Sheet createSheetInWorkspaceFromTemplate(long workspaceId, Sheet sheet, EnumSet<SheetTemplateInclusion> includes) throws SmartsheetException;
+    Sheet createSheetInWorkspaceFromTemplate(
+            long workspaceId,
+            Sheet sheet,
+            EnumSet<SheetTemplateInclusion> includes
+    ) throws SmartsheetException;
 
     /**
      * <p>Imports a sheet in given workspace.</p>
@@ -450,7 +469,13 @@ public interface SheetResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Sheet importCsvInWorkspace(long workspaceId, String file, String sheetName, Integer headerRowIndex, Integer primaryColumnIndex) throws SmartsheetException;
+    Sheet importCsvInWorkspace(
+            long workspaceId,
+            String file,
+            String sheetName,
+            Integer headerRowIndex,
+            Integer primaryColumnIndex
+    ) throws SmartsheetException;
 
     /**
      * <p>Imports a sheet in given workspace.</p>
@@ -470,7 +495,13 @@ public interface SheetResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Sheet importXlsxInWorkspace(long workspaceId, String file, String sheetName, Integer headerRowIndex, Integer primaryColumnIndex) throws SmartsheetException;
+    Sheet importXlsxInWorkspace(
+            long workspaceId,
+            String file,
+            String sheetName,
+            Integer headerRowIndex,
+            Integer primaryColumnIndex
+    ) throws SmartsheetException;
 
     /**
      * <p>Delete a sheet.</p>
@@ -515,7 +546,7 @@ public interface SheetResources {
      *
      * @param id the id
      * @return the sheet version (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException)
+     *     ResourceNotFoundException)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -547,7 +578,8 @@ public interface SheetResources {
      * <p>It mirrors to the following Smartsheet REST API method: GET /sheet/{sheetId}/publish</p>
      *
      * @param id the id
-     * @return the publish status (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null)
+     * @return the publish status (note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -565,7 +597,7 @@ public interface SheetResources {
      * @param id the id
      * @param publish the SheetPublish object limited.
      * @return the update SheetPublish object (note that if there is no such resource, this method will throw a
-     * ResourceNotFoundException rather than returning null).
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -594,7 +626,11 @@ public interface SheetResources {
      * @return the sheet
      * @throws SmartsheetException the smartsheet exception
      */
-    Sheet copySheet(long sheetId, ContainerDestination containerDestination, EnumSet<SheetCopyInclusion> includes) throws SmartsheetException;
+    Sheet copySheet(
+            long sheetId,
+            ContainerDestination containerDestination,
+            EnumSet<SheetCopyInclusion> includes
+    ) throws SmartsheetException;
 
     /**
      * <p>Creates a copy of the specified sheet.</p>
@@ -729,7 +765,6 @@ public interface SheetResources {
      * @return the associated discussion resources
      */
     SheetDiscussionResources discussionResources();
-
 
     /**
      * <p>Return the SheetCommentResources object that provides access to discussion resources associated with

--- a/src/main/java/com/smartsheet/api/SheetRowResources.java
+++ b/src/main/java/com/smartsheet/api/SheetRowResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.CopyOrMoveRowDirective;
 import com.smartsheet.api.models.CopyOrMoveRowResult;
@@ -77,7 +76,12 @@ public interface SheetRowResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    List<Row> addRows(long sheetId, List<Row> rows, EnumSet<RowInclusion> includes, EnumSet<ObjectExclusion> excludes ) throws SmartsheetException;
+    List<Row> addRows(
+            long sheetId,
+            List<Row> rows,
+            EnumSet<RowInclusion> includes,
+            EnumSet<ObjectExclusion> excludes
+    ) throws SmartsheetException;
 
     /**
      * <p>Insert rows to a sheet, allowing partial success. If a row cannot be inserted, it will fail, while the others may succeed..</p>
@@ -113,8 +117,12 @@ public interface SheetRowResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    PartialRowUpdateResult addRowsAllowPartialSuccess(long sheetId, List<Row> rows,
-                                                             EnumSet<RowInclusion> includes, EnumSet<ObjectExclusion> excludes) throws SmartsheetException;
+    PartialRowUpdateResult addRowsAllowPartialSuccess(
+            long sheetId,
+            List<Row> rows,
+            EnumSet<RowInclusion> includes,
+            EnumSet<ObjectExclusion> excludes
+    ) throws SmartsheetException;
 
     /**
      * <p>Get a row.</p>
@@ -126,7 +134,7 @@ public interface SheetRowResources {
      * @param includes optional objects to include
      * @param excludes optional objects to exclude
      * @return the created row (note that if there is no such resource, this method will throw ResourceNotFoundException rather
-     * than returning null).
+     *     than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -261,7 +269,12 @@ public interface SheetRowResources {
      * @return a list of rows
      * @throws SmartsheetException the smartsheet exception
      */
-    List<Row> updateRows(long sheetId, List<Row> rows, EnumSet<RowInclusion> includes, EnumSet<ObjectExclusion> excludes) throws SmartsheetException;
+    List<Row> updateRows(
+            long sheetId,
+            List<Row> rows,
+            EnumSet<RowInclusion> includes,
+            EnumSet<ObjectExclusion> excludes
+    ) throws SmartsheetException;
 
     /**
      * <p>Update rows, but allow partial success. The PartialRowUpdateResult will contain the successful
@@ -305,8 +318,12 @@ public interface SheetRowResources {
      * @return a list of rows
      * @throws SmartsheetException the smartsheet exception
      */
-    PartialRowUpdateResult updateRowsAllowPartialSuccess(long sheetId, List<Row> rows,
-                                                                EnumSet<RowInclusion> includes, EnumSet<ObjectExclusion> excludes) throws SmartsheetException;
+    PartialRowUpdateResult updateRowsAllowPartialSuccess(
+            long sheetId,
+            List<Row> rows,
+            EnumSet<RowInclusion> includes,
+            EnumSet<ObjectExclusion> excludes
+    ) throws SmartsheetException;
 
     /**
      * <p>Moves Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</p>
@@ -328,7 +345,12 @@ public interface SheetRowResources {
      * @return the result object
      * @throws SmartsheetException the smartsheet exception
      */
-    CopyOrMoveRowResult moveRows(Long sheetId, EnumSet<RowMoveInclusion> includes, Boolean ignoreRowsNotFound, CopyOrMoveRowDirective moveParameters) throws SmartsheetException;
+    CopyOrMoveRowResult moveRows(
+            Long sheetId,
+            EnumSet<RowMoveInclusion> includes,
+            Boolean ignoreRowsNotFound,
+            CopyOrMoveRowDirective moveParameters
+    ) throws SmartsheetException;
 
     /**
      * <p>Copies Row(s) from the Sheet specified in the URL to (the bottom of) another sheet.</p>
@@ -350,7 +372,12 @@ public interface SheetRowResources {
      * @return the result object
      * @throws SmartsheetException the smartsheet exception
      */
-    CopyOrMoveRowResult copyRows(Long sheetId, EnumSet<RowCopyInclusion> includes, Boolean ignoreRowsNotFound, CopyOrMoveRowDirective copyParameters) throws SmartsheetException;
+    CopyOrMoveRowResult copyRows(
+            Long sheetId,
+            EnumSet<RowCopyInclusion> includes,
+            Boolean ignoreRowsNotFound,
+            CopyOrMoveRowDirective copyParameters
+    ) throws SmartsheetException;
 
     /**
      * <p>Creates an object of RowAttachmentResources.</p>

--- a/src/main/java/com/smartsheet/api/SheetSummaryResources.java
+++ b/src/main/java/com/smartsheet/api/SheetSummaryResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.BulkItemResult;
 import com.smartsheet.api.models.PagedResult;
@@ -132,7 +131,11 @@ public interface SheetSummaryResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    List<SummaryField> updateSheetSummaryFields(long sheetId, List<SummaryField> fields, Boolean renameIfConflict) throws SmartsheetException;
+    List<SummaryField> updateSheetSummaryFields(
+            long sheetId,
+            List<SummaryField> fields,
+            Boolean renameIfConflict
+    ) throws SmartsheetException;
 
     /**
      * <p>Update fields in a sheet summary.</p>
@@ -210,11 +213,17 @@ public interface SheetSummaryResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Result<SummaryField> addSheetSummaryFieldImage(long sheetId, long fieldId, File file, String contentType, String altText) throws SmartsheetException, FileNotFoundException;
+    Result<SummaryField> addSheetSummaryFieldImage(
+            long sheetId,
+            long fieldId,
+            File file,
+            String contentType,
+            String altText
+    ) throws SmartsheetException, FileNotFoundException;
 
     /**
      * Adds an image to the sheet summary field.
-     *
+     * <p>
      * It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/summary/fields/{fieldId}/images
      *
      * @param sheetId the sheet id
@@ -231,6 +240,12 @@ public interface SheetSummaryResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Result<SummaryField> addSheetSummaryFieldImage(long sheetId, long fieldId, InputStream inputStream, String contentType,
-                                                          long contentLength, String altText) throws SmartsheetException, FileNotFoundException;
+    Result<SummaryField> addSheetSummaryFieldImage(
+            long sheetId,
+            long fieldId,
+            InputStream inputStream,
+            String contentType,
+            long contentLength,
+            String altText
+    ) throws SmartsheetException, FileNotFoundException;
 }

--- a/src/main/java/com/smartsheet/api/SheetUpdateRequestResources.java
+++ b/src/main/java/com/smartsheet/api/SheetUpdateRequestResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,7 @@ import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.SentUpdateRequest;
 import com.smartsheet.api.models.UpdateRequest;
+
 public interface SheetUpdateRequestResources {
 
     /**
@@ -50,7 +51,8 @@ public interface SheetUpdateRequestResources {
      *
      * @param sheetId the Id of the sheet
      * @param updateRequestId the update request Id
-     * @return the update request resource (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null).
+     * @return the update request resource (note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -135,7 +137,8 @@ public interface SheetUpdateRequestResources {
      *
      * @param sheetId the Id of the sheet
      * @param sentUpdateRequestId the sent update request Id
-     * @return the sent update request resource (note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null).
+     * @return the sent update request resource (note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null).
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/SightResources.java
+++ b/src/main/java/com/smartsheet/api/SightResources.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/Smartsheet.java
+++ b/src/main/java/com/smartsheet/api/Smartsheet.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/SmartsheetBuilder.java
+++ b/src/main/java/com/smartsheet/api/SmartsheetBuilder.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.internal.SmartsheetImpl;
 import com.smartsheet.api.internal.http.HttpClient;
@@ -151,7 +149,6 @@ public class SmartsheetBuilder {
      *
      * <p>This interface is only valid when the DefaultHttpClient is used.</p>
      *
-     * @param maxRetryTimeMillis
      * @return the smartsheet builder
      */
     public SmartsheetBuilder setMaxRetryTimeMillis(long maxRetryTimeMillis) {
@@ -182,7 +179,6 @@ public class SmartsheetBuilder {
         this.changeAgent = changeAgent;
         return this;
     }
-
 
     /**
      * <p>Gets the http client.</p>
@@ -254,19 +250,25 @@ public class SmartsheetBuilder {
      * @throws IllegalStateException if accessToken isn't set yet.
      */
     public Smartsheet build() {
-        if(baseURI == null){
+        if (baseURI == null) {
             baseURI = DEFAULT_BASE_URI;
         }
 
-        if(accessToken == null){
+        if (accessToken == null) {
             accessToken = System.getenv("SMARTSHEET_ACCESS_TOKEN");
         }
 
         SmartsheetImpl smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, jsonSerializer);
 
-        if (changeAgent != null) { smartsheet.setChangeAgent(changeAgent); }
-        if (assumedUser != null) { smartsheet.setAssumedUser(assumedUser); }
-        if (maxRetryTimeMillis != null) { smartsheet.setMaxRetryTimeMillis(maxRetryTimeMillis); }
+        if (changeAgent != null) {
+            smartsheet.setChangeAgent(changeAgent);
+        }
+        if (assumedUser != null) {
+            smartsheet.setAssumedUser(assumedUser);
+        }
+        if (maxRetryTimeMillis != null) {
+            smartsheet.setMaxRetryTimeMillis(maxRetryTimeMillis);
+        }
 
         return smartsheet;
     }

--- a/src/main/java/com/smartsheet/api/SmartsheetException.java
+++ b/src/main/java/com/smartsheet/api/SmartsheetException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,9 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
-
 
 /**
  * <p>This is the base class for all exceptions thrown from the Smartsheet SDK.</p>

--- a/src/main/java/com/smartsheet/api/SmartsheetFactory.java
+++ b/src/main/java/com/smartsheet/api/SmartsheetFactory.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.internal.SmartsheetImpl;
 
@@ -53,8 +52,6 @@ public class SmartsheetFactory {
     /**
      * <p>Creates a Smartsheet client with default parameters.</p>
      *
-     * @param accessToken
-     *
      * @return the Smartsheet client
      */
     public static Smartsheet createDefaultClient(String accessToken) {
@@ -76,8 +73,6 @@ public class SmartsheetFactory {
 
     /**
      * <p>Creates a Smartsheet client with default parameters using the Smartsheetgov URI.</p>
-     *
-     * @param accessToken
      *
      * @return the Smartsheet client
      */

--- a/src/main/java/com/smartsheet/api/SmartsheetRestException.java
+++ b/src/main/java/com/smartsheet/api/SmartsheetRestException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,13 +20,11 @@ package com.smartsheet.api;
  * %[license]
  */
 
-
-
 import com.smartsheet.api.models.Error;
 
 /**
  * <p>This is the exception to indicate errors (Error objects of Smartsheet REST API) returned from Smartsheet REST API.</p>
- * 
+ *
  * <p>Thread safety: Exceptions are not thread safe.</p>
  */
 public class SmartsheetRestException extends SmartsheetException {
@@ -66,8 +64,6 @@ public class SmartsheetRestException extends SmartsheetException {
         detail = error.getDetail();
     }
 
-
-
     /**
      * <p>Returns the error code.</p>
      *
@@ -82,12 +78,16 @@ public class SmartsheetRestException extends SmartsheetException {
      *
      * @return the refId
      */
-    public String getRefId() { return this.refId; }
+    public String getRefId() {
+        return this.refId;
+    }
 
     /**
      * <p>Returns the error detail</p>
      *
      * @return the error detail
      */
-    public Object getDetail() { return this.detail; }
+    public Object getDetail() {
+        return this.detail;
+    }
 }

--- a/src/main/java/com/smartsheet/api/TemplateResources.java
+++ b/src/main/java/com/smartsheet/api/TemplateResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
@@ -38,7 +36,6 @@ public interface TemplateResources {
      *
      * <p>It mirrors to the following Smartsheet REST API method: GET /templates</p>
      *
-     * @param parameters the pagination parameters
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -46,6 +43,7 @@ public interface TemplateResources {
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
+     * @param parameters the pagination parameters
      * @return all templates (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */
@@ -56,7 +54,6 @@ public interface TemplateResources {
      *
      * <p>It mirrors to the following Smartsheet REST API method: GET /templates/public</p>
      *
-     * @param parameters the pagination parameters
      * Exceptions:
      *   - InvalidRequestException : if there is any problem with the REST API request
      *   - AuthorizationException : if there is any problem with the REST API authorization(access token)
@@ -64,6 +61,7 @@ public interface TemplateResources {
      *   - SmartsheetRestException : if there is any other REST API related error occurred during the operation
      *   - SmartsheetException : if there is any other error occurred during the operation
      *
+     * @param parameters the pagination parameters
      * @return all templates (note that empty list will be returned if there is none)
      * @throws SmartsheetException the smartsheet exception
      */

--- a/src/main/java/com/smartsheet/api/TokenResources.java
+++ b/src/main/java/com/smartsheet/api/TokenResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +37,7 @@ public interface TokenResources {
 
     /**
      * Revoke access token.
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if url is null or empty
      *   - InvalidTokenRequestException : if the token request is invalid

--- a/src/main/java/com/smartsheet/api/Trace.java
+++ b/src/main/java/com/smartsheet/api/Trace.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import org.slf4j.LoggerFactory;
 
@@ -55,14 +54,20 @@ public enum Trace {
     },
     ;
     // this makes it possible to add other (or additional) Traces for specific types
-    public boolean addReplacements(Set<Trace> traces) { return false; }
+    public boolean addReplacements(Set<Trace> traces) {
+        return false;
+    }
 
+    /**
+     * Parse the string into a Set of Traces
+     */
     public static Set<Trace> parse(String traces) {
         if (traces == null || traces.trim().isEmpty()) {
             return Collections.emptySet();
         }
         String[] parts = traces.split("[, ]+");
-        Set<Trace> results = new HashSet<>(parts.length + parts.length / 2); // pad for load-factor
+        // pad for load-factor
+        Set<Trace> results = new HashSet<>(parts.length + parts.length / 2);
         for (String part : parts) {
             try {
                 Trace trace = valueOf(part);

--- a/src/main/java/com/smartsheet/api/UserResources.java
+++ b/src/main/java/com/smartsheet/api/UserResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.AlternateEmail;
 import com.smartsheet.api.models.DeleteUserParameters;
@@ -265,7 +264,8 @@ public interface UserResources {
      *
      * @param userId the id of the user
      * @param altEmailId the alternate email id for the alternate email to retrieve.
-     * @return the resource. Note that if there is no such resource, this method will throw ResourceNotFoundException rather than returning null.
+     * @return the resource. Note that if there is no such resource, this method will throw
+     *     ResourceNotFoundException rather than returning null.
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)

--- a/src/main/java/com/smartsheet/api/WebhookResources.java
+++ b/src/main/java/com/smartsheet/api/WebhookResources.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/WorkspaceFolderResources.java
+++ b/src/main/java/com/smartsheet/api/WorkspaceFolderResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.models.Folder;
 import com.smartsheet.api.models.PagedResult;

--- a/src/main/java/com/smartsheet/api/WorkspaceResources.java
+++ b/src/main/java/com/smartsheet/api/WorkspaceResources.java
@@ -9,9 +9,9 @@ package com.smartsheet.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,7 +63,7 @@ public interface WorkspaceResources {
      * @param includes the include parameters
      * @param loadAll the loadAll boolean value
      * @return the workspace (note that if there is no such resource, this method will throw ResourceNotFoundException
-     * rather than returning null)
+     *     rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -71,7 +71,7 @@ public interface WorkspaceResources {
      * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
      * @throws SmartsheetException if there is any other error during the operation
      */
-    Workspace getWorkspace(long id, Boolean loadAll, EnumSet<SourceInclusion> includes ) throws SmartsheetException;
+    Workspace getWorkspace(long id, Boolean loadAll, EnumSet<SourceInclusion> includes) throws SmartsheetException;
 
     /**
      * <p>Create a workspace.</p>
@@ -96,7 +96,7 @@ public interface WorkspaceResources {
      *
      * @param workspace the workspace to update
      * @return the updated workspace (note that if there is no such resource, this method will throw
-     * ResourceNotFoundException rather than returning null)
+     *     ResourceNotFoundException rather than returning null)
      * @throws IllegalArgumentException if any argument is null or empty string
      * @throws InvalidRequestException if there is any problem with the REST API request
      * @throws AuthorizationException if there is any problem with  the REST API authorization (access token)
@@ -141,7 +141,12 @@ public interface WorkspaceResources {
      * @return the folder
      * @throws SmartsheetException the smartsheet exception
      */
-    Workspace copyWorkspace(long workspaceId, ContainerDestination containerDestination, EnumSet<WorkspaceCopyInclusion> includes, EnumSet<WorkspaceRemapExclusion> skipRemap) throws SmartsheetException;
+    Workspace copyWorkspace(
+            long workspaceId,
+            ContainerDestination containerDestination,
+            EnumSet<WorkspaceCopyInclusion> includes,
+            EnumSet<WorkspaceRemapExclusion> skipRemap
+    ) throws SmartsheetException;
 
     /**
      * <p>Creates a copy of the specified workspace.</p>

--- a/src/main/java/com/smartsheet/api/internal/http/AndroidHttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/AndroidHttpClient.java
@@ -49,6 +49,8 @@ public class AndroidHttpClient implements HttpClient {
 
     private static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json");
 
+    private static final String ERROR_OCCURRED = "Error occurred.";
+
     /**
      * Represents the underlying OkHttpClient.
      * <p>
@@ -140,7 +142,7 @@ public class AndroidHttpClient implements HttpClient {
             try {
                 builder.url(smartsheetRequest.getUri().toURL());
             } catch (MalformedURLException e) {
-                throw new HttpClientException("Error occurred.", e);
+                throw new HttpClientException(ERROR_OCCURRED, e);
             }
 
             // Clone our headers to request
@@ -164,7 +166,7 @@ public class AndroidHttpClient implements HttpClient {
                         break;
                 }
             } catch (IOException e) {
-                throw new HttpClientException("Error occurred.", e);
+                throw new HttpClientException(ERROR_OCCURRED, e);
             }
 
             // mark the body so we can reset on retry
@@ -223,7 +225,7 @@ public class AndroidHttpClient implements HttpClient {
                 this.releaseConnection();
 
             } catch (IOException ex) {
-                throw new HttpClientException("Error occurred.", ex);
+                throw new HttpClientException(ERROR_OCCURRED, ex);
             }
         }
         return smartsheetResponse;

--- a/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
@@ -62,11 +62,11 @@ import java.util.Random;
 import java.util.Set;
 
 /**
- * This is the Apache HttpClient (http://hc.apache.org/httpcomponents-client-ga/index.html) based HttpClient
- * implementation.
- *
+ * This is the Apache HttpClient based HttpClient implementation.
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and the underlying Apache CloseableHttpClient is
  * thread safe.
+ * @see <a href="http://hc.apache.org/httpcomponents-client-ga/index.html">Apache HttpClient</a>
  */
 public class DefaultHttpClient implements HttpClient {
 
@@ -120,6 +120,9 @@ public class DefaultHttpClient implements HttpClient {
     /** whether to log pretty or compact */
     private boolean tracePrettyPrint = TRACE_PRETTY_PRINT_DEFAULT;
 
+    private static final String LOG_ARG = "{}";
+    private static final String ERROR_OCCURRED = "Error occurred.";
+
     /**
      * Constructor.
      */
@@ -158,10 +161,10 @@ public class DefaultHttpClient implements HttpClient {
                 response.getStatusCode(), durationMillis);
         if (response.getStatusCode() != 200) {
             // log the request and response on error
-            logger.warn("{}", RequestAndResponseData.of(request, requestEntity, response, responseEntity, REQUEST_RESPONSE));
+            logger.warn(LOG_ARG, RequestAndResponseData.of(request, requestEntity, response, responseEntity, REQUEST_RESPONSE));
         } else {
             // log the summary request and response on success
-            logger.debug("{}", RequestAndResponseData.of(request, requestEntity, response, responseEntity, REQUEST_RESPONSE_SUMMARY));
+            logger.debug(LOG_ARG, RequestAndResponseData.of(request, requestEntity, response, responseEntity, REQUEST_RESPONSE_SUMMARY));
         }
     }
 
@@ -322,7 +325,7 @@ public class DefaultHttpClient implements HttpClient {
             } catch (ClientProtocolException e) {
                 try {
                     logger.warn("ClientProtocolException " + e.getMessage());
-                    logger.warn("{}", RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
+                    logger.warn(LOG_ARG, RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
                             responseEntityCopy, REQUEST_RESPONSE_SUMMARY));
                     // if this is a PUT and was retried by the http client, the body content stream is at the
                     // end and is a NonRepeatableRequest. If we marked the body content stream prior to execute,
@@ -335,11 +338,11 @@ public class DefaultHttpClient implements HttpClient {
                     }
                 } catch (IOException ignore) {
                 }
-                throw new HttpClientException("Error occurred.", e);
+                throw new HttpClientException(ERROR_OCCURRED, e);
             } catch (NoHttpResponseException e) {
                 try {
                     logger.warn("NoHttpResponseException " + e.getMessage());
-                    logger.warn("{}", RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
+                    logger.warn(LOG_ARG, RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
                             responseEntityCopy, REQUEST_RESPONSE_SUMMARY));
                     // check to see if the response was empty and this was a POST. All other HTTP methods
                     // will be automatically retried by the http client.
@@ -352,14 +355,14 @@ public class DefaultHttpClient implements HttpClient {
                     }
                 } catch (IOException ignore) {
                 }
-                throw new HttpClientException("Error occurred.", e);
+                throw new HttpClientException(ERROR_OCCURRED, e);
             } catch (IOException e) {
                 try {
-                    logger.warn("{}", RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
+                    logger.warn(LOG_ARG, RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
                             responseEntityCopy, REQUEST_RESPONSE_SUMMARY));
                 } catch (IOException ignore) {
                 }
-                throw new HttpClientException("Error occurred.", e);
+                throw new HttpClientException(ERROR_OCCURRED, e);
             }
         }
         return smartsheetResponse;

--- a/src/main/java/com/smartsheet/api/internal/http/HttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpClient.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,21 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
 import java.io.Closeable;
 
 /**
  * This interface defines methods to make an HTTP request.
- *
+ * <p>
  * Thread Safety: Implementation of this interface must be thread safe.
  */
 public interface HttpClient extends Closeable {
     /**
      * Make an HTTP request and return the response.
-     *
+     * <p>
      * Parameters: - request : the HTTP request
-     *
+     * <p>
      * Returns: the HTTP response
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - HttpClientException : if there is any other
      * error occurred during the operation
      *

--- a/src/main/java/com/smartsheet/api/internal/http/HttpClientException.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpClientException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,13 +20,11 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
-
 import com.smartsheet.api.SmartsheetException;
 
 /**
  * This is the exception throw by HttpClient to indicate errors occurred during HTTP operation.
- * 
+ * <p>
  * Thread safety: Exceptions are not thread safe.
  */
 public class HttpClientException extends SmartsheetException {

--- a/src/main/java/com/smartsheet/api/internal/http/HttpEntity.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpEntity.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,32 +20,31 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
 import java.io.InputStream;
 
 /**
  * This class represents an HTTP Entity (http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html).
- *
+ * <p>
  * Thread Safety: This class is not thread safe since it's mutable.
  */
 public class HttpEntity {
     /**
      * Represents the content type.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private String contentType;
 
     /**
      * Represents the content length.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private long contentLength;
 
     /**
      * Represents the content as an InputStream.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private InputStream content;

--- a/src/main/java/com/smartsheet/api/internal/http/HttpEntitySnapshot.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpEntitySnapshot.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal.http;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.internal.util.StreamUtil;
 import org.apache.http.entity.ContentType;

--- a/src/main/java/com/smartsheet/api/internal/http/HttpMessage.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpMessage.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,26 +20,24 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
-
 import java.util.Map;
 
 /**
  * This is the base class of HTTP messages, it holds headers and an HttpEntity.
- *
+ * <p>
  * Thread Safety: This class is not thread safe since it's mutable.
  */
 public abstract class HttpMessage {
     /**
      * Represents the HTTP headers.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private Map<String, String> headers;
 
     /**
      * Represents the HTTP entity.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private HttpEntity entity;

--- a/src/main/java/com/smartsheet/api/internal/http/HttpMethod.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpMethod.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,11 +20,9 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
-
 /**
  * Represents HTTP methods.
- *
+ * <p>
  * Thread Safety: This enumeration is thread safe as it is immutable.
  */
 public enum HttpMethod {

--- a/src/main/java/com/smartsheet/api/internal/http/HttpRequest.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpRequest.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,26 +20,24 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
-
 import java.net.URI;
 
 /**
  * This class represents an HTTP request.
- *
+ * <p>
  * Thread Safety: This class is not thread safe since it's mutable.
  */
 public class HttpRequest extends HttpMessage {
     /**
      * Represents the URI.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private URI uri;
 
     /**
      * Represents the HTTP method.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private HttpMethod method;

--- a/src/main/java/com/smartsheet/api/internal/http/HttpResponse.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpResponse.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.http;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,17 +20,15 @@ package com.smartsheet.api.internal.http;
  * %[license]
  */
 
-
-
 /**
  * This class represents an HTTP response.
- *
+ * <p>
  * Thread Safety: This class is not thread safe since it's mutable.
  */
 public class HttpResponse extends HttpMessage {
     /**
      * Represents the response status code.
-     *
+     * <p>
      * It has a pair of setter/getter (not shown on class diagram for brevity).
      */
     private int statusCode;

--- a/src/main/java/com/smartsheet/api/internal/http/RequestAndResponseData.java
+++ b/src/main/java/com/smartsheet/api/internal/http/RequestAndResponseData.java
@@ -104,14 +104,21 @@ public class RequestAndResponseData {
                 return dataObject;
             }
 
+            /**
+             * Add a command
+             */
             public HttpPayloadData.Builder withCommand(String command) {
                 getDataObject().command = command;
                 return this;
             }
 
+            /**
+             * Build the RequestData
+             */
             public RequestData build() {
                 try {
-                    return dataObject;  // if nothing was added then nothing was built (i.e., this can be null)
+                    // if nothing was added then nothing was built (i.e., this can be null)
+                    return dataObject;
                 } finally {
                     reset();
                 }
@@ -142,11 +149,17 @@ public class RequestAndResponseData {
                 return dataObject;
             }
 
+            /**
+             * Add a status
+             */
             public HttpPayloadData.Builder withStatus(String status) {
                 getDataObject().status = status;
                 return this;
             }
 
+            /**
+             * Build the ResponseData
+             */
             public ResponseData build() {
                 try {
                     // if nothing was added then nothing was built (i.e., this can be null)
@@ -159,6 +172,7 @@ public class RequestAndResponseData {
     }
 
     private static int TRUNCATE_LENGTH = Integer.getInteger("Smartsheet.trace.truncateLen", 1024);
+    private static final String NULL_STRING = "null";
 
     public final RequestData request;
     public final ResponseData response;
@@ -173,71 +187,94 @@ public class RequestAndResponseData {
         return toString(false);
     }
 
+    /**
+     * Convert to a String
+     */
     public String toString(boolean pretty) {
-        final String EOL = pretty ? "\n" : "";
-        final String INDENT  = pretty ? "  " : "";
-        final String INDENT2 = INDENT + INDENT;
-        final String INDENT3 = INDENT2 + INDENT;
+        final String eol = pretty ? "\n" : "";
+        final String indent = pretty ? "  " : "";
+        final String doubleIndent = indent + indent;
+        final String tripleIndent = doubleIndent + indent;
 
         StringBuilder buf = new StringBuilder();
-        buf.append("{").append(EOL);
-        buf.append(INDENT).append("request:");
+        buf.append("{").append(eol);
+        buf.append(indent).append("request:");
         if (request == null) {
-            buf.append("null,").append(EOL);
+            buf.append("null,").append(eol);
         } else {
-            buf.append("{").append(EOL);
-            buf.append(INDENT2).append("command:'").append(request.getCommand()).append("',").append(EOL);
+            buf.append("{").append(eol);
+            buf
+                    .append(doubleIndent)
+                    .append("command:'")
+                    .append(request.getCommand())
+                    .append("'")
+                    .append(",")
+                    .append(eol);
             if (request.hasHeaders()) {
-                buf.append(INDENT2).append("headers:");
+                buf.append(doubleIndent).append("headers:");
                 if (request.getHeaders() == null) {
-                    buf.append("null");
+                    buf.append(NULL_STRING);
                 } else {
-                    buf.append("{").append(EOL);
+                    buf.append("{").append(eol);
                     for (Map.Entry<String, String> header : request.headers.entrySet()) {
-                        buf.append(INDENT3).append("'").append(header.getKey()).append("':'").append(header.getValue()).append("',").append(EOL);
+                        buf
+                                .append(tripleIndent)
+                                .append("'")
+                                .append(header.getKey())
+                                .append("':'")
+                                .append(header.getValue())
+                                .append("'")
+                                .append(",")
+                                .append(eol);
                     }
-                    buf.append(INDENT2).append("},").append(EOL);
+                    buf.append(doubleIndent).append("}").append(",").append(eol);
                 }
             }
             if (request.hasBody()) {
-                buf.append(INDENT2).append("body:");
+                buf.append(doubleIndent).append("body:");
                 if (request.body == null) {
-                    buf.append("null");
+                    buf.append(NULL_STRING);
                 } else {
                     buf.append("'").append(request.body).append("'");
                 }
-                buf.append(EOL);
+                buf.append(eol);
             }
-            buf.append(INDENT).append("},").append(EOL);
+            buf.append(indent).append("},").append(eol);
         }
-        buf.append(INDENT).append("response:");
+        buf.append(indent).append("response:");
         if (response == null) {
-            buf.append("null").append(EOL);
+            buf.append(NULL_STRING).append(eol);
         } else {
-            buf.append("{").append(EOL);
-            buf.append(INDENT2).append("status:'").append(response.getStatus()).append("',").append(EOL);
+            buf.append("{").append(eol);
+            buf.append(doubleIndent).append("status:'").append(response.getStatus()).append("',").append(eol);
             if (response.hasHeaders()) {
-                buf.append(INDENT2).append("headers:");
+                buf.append(doubleIndent).append("headers:");
                 if (response.getHeaders() == null) {
-                    buf.append("null");
+                    buf.append(NULL_STRING);
                 } else {
-                    buf.append("{").append(EOL);
+                    buf.append("{").append(eol);
                     for (Map.Entry<String, String> header : response.headers.entrySet()) {
-                        buf.append(INDENT3).append("'").append(header.getKey()).append("':'").append(header.getValue()).append("',").append(EOL);
+                        buf
+                                .append(tripleIndent)
+                                .append("'")
+                                .append(header.getKey())
+                                .append("':'")
+                                .append(header.getValue())
+                                .append("',").append(eol);
                     }
-                    buf.append(INDENT2).append("},").append(EOL);
+                    buf.append(doubleIndent).append("},").append(eol);
                 }
             }
             if (response.hasBody()) {
-                buf.append(INDENT2).append("body:");
+                buf.append(doubleIndent).append("body:");
                 if (response.body == null) {
-                    buf.append("null");
+                    buf.append(NULL_STRING);
                 } else {
                     buf.append("'").append(response.body).append("'");
                 }
-                buf.append(EOL);
+                buf.append(eol);
             }
-            buf.append(INDENT).append("}").append(EOL);
+            buf.append(indent).append("}").append(eol);
         }
         buf.append("}");
         return buf.toString();
@@ -273,7 +310,9 @@ public class RequestAndResponseData {
                 if (traces.contains(Trace.RequestBody)) {
                     requestBuilder.setBody(binaryBody ? binaryBody(requestEntity) : getContentAsText(requestEntity));
                 } else if (traces.contains(Trace.RequestBodySummary)) {
-                    requestBuilder.setBody(binaryBody ? binaryBody(requestEntity) : truncateAsNeeded(getContentAsText(requestEntity), TRUNCATE_LENGTH));
+                    requestBuilder.setBody(binaryBody
+                            ? binaryBody(requestEntity)
+                            : truncateAsNeeded(getContentAsText(requestEntity), TRUNCATE_LENGTH));
                 }
             }
         }
@@ -295,7 +334,9 @@ public class RequestAndResponseData {
                 if (traces.contains(Trace.ResponseBody)) {
                     responseBuilder.setBody(binaryBody ? binaryBody(responseEntity) : getContentAsText(responseEntity));
                 } else if (traces.contains(Trace.ResponseBodySummary)) {
-                    responseBuilder.setBody(binaryBody ? binaryBody(responseEntity) : truncateAsNeeded(getContentAsText(responseEntity), TRUNCATE_LENGTH));
+                    responseBuilder.setBody(binaryBody
+                            ? binaryBody(responseEntity)
+                            : truncateAsNeeded(getContentAsText(responseEntity), TRUNCATE_LENGTH));
                 }
             }
         }
@@ -306,6 +347,9 @@ public class RequestAndResponseData {
         return "**possibly-binary(type:" + entity.getContentType() + ", len:" + entity.getContentLength() + ")**";
     }
 
+    /**
+     * Get the Content as a String
+     */
     public static String getContentAsText(HttpEntitySnapshot entity) {
         if (entity == null) {
             return "";
@@ -316,6 +360,9 @@ public class RequestAndResponseData {
         return contentAsText;
     }
 
+    /**
+     * Truncate the string to the desired length if needed
+     */
     public static String truncateAsNeeded(String string, int truncateLen) {
         if (truncateLen == -1) {
             return string;

--- a/src/main/java/com/smartsheet/api/internal/json/CellLinkSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/CellLinkSerializer.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal.json;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -33,6 +32,9 @@ public class CellLinkSerializer extends JsonSerializer<CellLink> {
 
     private final com.fasterxml.jackson.databind.JsonSerializer<Object> defaultSerializer;
 
+    /**
+     * Constructor
+     */
     public CellLinkSerializer(JsonSerializer<Object> defaultSerializer) {
         Util.throwIfNull(defaultSerializer);
         this.defaultSerializer = defaultSerializer;
@@ -42,10 +44,9 @@ public class CellLinkSerializer extends JsonSerializer<CellLink> {
     public void serialize(CellLink cellLink, JsonGenerator gen, SerializerProvider serializers)
             throws IOException {
 
-        if(cellLink.isNull()) {
+        if (cellLink.isNull()) {
             gen.writeNull();
-        }
-        else {
+        } else {
             defaultSerializer.serialize(cellLink, gen, serializers);
         }
     }

--- a/src/main/java/com/smartsheet/api/internal/json/CellSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/CellSerializer.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,16 +39,17 @@ public class CellSerializer extends JsonSerializer<Cell> {
 
     private final JsonSerializer<Object> defaultSerializer;
 
+    /**
+     * Constructor
+     */
     public CellSerializer(JsonSerializer<Object> defaultSerializer) {
         Util.throwIfNull(defaultSerializer);
         this.defaultSerializer = defaultSerializer;
     }
 
     @Override
-    public void serialize(Cell cell, JsonGenerator gen, SerializerProvider serializers)
-            throws IOException  {
-
-        if(cell.getLinkInFromCell() != null && cell.getValue() == null) {
+    public void serialize(Cell cell, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (cell.getLinkInFromCell() != null && cell.getValue() == null) {
             // setting value to ExplicitNull here will force serialization of a null
             cell.setValue(new ExplicitNull());
         }

--- a/src/main/java/com/smartsheet/api/internal/json/CellSerializerModifier.java
+++ b/src/main/java/com/smartsheet/api/internal/json/CellSerializerModifier.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,8 +36,7 @@ public class CellSerializerModifier extends BeanSerializerModifier {
     public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc, JsonSerializer<?> serializer) {
         if (beanDesc.getBeanClass() == Cell.class) {
             return new CellSerializer((JsonSerializer<Object>) serializer);
-        }
-        else if (beanDesc.getBeanClass() == CellLink.class) {
+        } else if (beanDesc.getBeanClass() == CellLink.class) {
             return new CellLinkSerializer((JsonSerializer<Object>) serializer);
         }
         return serializer;

--- a/src/main/java/com/smartsheet/api/internal/json/ErrorDeserializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/ErrorDeserializer.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,24 +42,26 @@ public class ErrorDeserializer extends JsonDeserializer<com.smartsheet.api.model
 
         final com.smartsheet.api.models.Error error = new com.smartsheet.api.models.Error();
 
-        if(jp.getCurrentToken() == JsonToken.START_OBJECT) {
+        if (jp.getCurrentToken() == JsonToken.START_OBJECT) {
             JsonNode node = jp.getCodec().readTree(jp);
-            if(node.get("errorCode") != null)
+            if (node.get("errorCode") != null) {
                 error.setErrorCode(node.get("errorCode").asInt());
-            if(node.get("message") != null)
+            }
+            if (node.get("message") != null) {
                 error.setMessage(node.get("message").asText());
-            if(node.get("refId") != null)
+            }
+            if (node.get("refId") != null) {
                 error.setRefId(node.get("refId").asText());
+            }
             JsonNode detail = node.get("detail");
-            if(detail != null) {
-                if(detail.isArray()) {
-                    String _as_text = detail.toString();
-                    List<ErrorDetail> details = mapper.readValue(_as_text,
-                            new TypeReference<List<ErrorDetail>>(){});
+            if (detail != null) {
+                if (detail.isArray()) {
+                    String asText = detail.toString();
+                    List<ErrorDetail> details = mapper.readValue(asText, new TypeReference<List<ErrorDetail>>(){});
                     error.setDetail(details);
-                }
-                else
+                } else {
                     error.setDetail(mapper.treeToValue(detail, ErrorDetail.class));
+                }
             }
             return error;
         }

--- a/src/main/java/com/smartsheet/api/internal/json/FormatDeserializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/FormatDeserializer.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/internal/json/HyperlinkSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/HyperlinkSerializer.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,24 +27,27 @@ import com.smartsheet.api.models.Hyperlink;
 
 import java.io.IOException;
 
-public class HyperlinkSerializer extends JsonSerializer<Hyperlink>{
+public class HyperlinkSerializer extends JsonSerializer<Hyperlink> {
 
     @Override
     public void serialize(Hyperlink value, JsonGenerator gen, SerializerProvider serializers)
             throws IOException {
-        if(value.isNull()) {
+        if (value.isNull()) {
             gen.writeNull();
-        }
-        else {
+        } else {
             gen.writeStartObject();
-            if(value.getUrl() != null)
+            if (value.getUrl() != null) {
                 gen.writeStringField("url", value.getUrl());
-            if(value.getReportId() != null)
+            }
+            if (value.getReportId() != null) {
                 gen.writeNumberField("reportId", value.getReportId());
-            if(value.getSheetId() != null)
+            }
+            if (value.getSheetId() != null) {
                 gen.writeNumberField("sheetId", value.getSheetId());
-            if(value.getSightId() != null)
+            }
+            if (value.getSightId() != null) {
                 gen.writeNumberField("sightId", value.getSightId());
+            }
             gen.writeEndObject();
         }
     }

--- a/src/main/java/com/smartsheet/api/internal/json/JSONSerializerException.java
+++ b/src/main/java/com/smartsheet/api/internal/json/JSONSerializerException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,13 +20,11 @@ package com.smartsheet.api.internal.json;
  * %[license]
  */
 
-
-
 import com.smartsheet.api.SmartsheetException;
 
 /**
  * This is the exception throw by JSONSerializer to indicate errors occurred during JSON serialization/de-serialization.
- *
+ * <p>
  * Thread safety: Exceptions are not thread safe.
  */
 public class JSONSerializerException extends SmartsheetException {

--- a/src/main/java/com/smartsheet/api/internal/json/JacksonJsonSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/JacksonJsonSerializer.java
@@ -54,16 +54,16 @@ import java.util.TimeZone;
 
 /**
  * This is the Jackson based JsonSerializer implementation.
- *
+ * <p>
  * Thread Safety: This class is thread safe because it is immutable and the underlying Jackson ObjectMapper is thread
  * safe as long as it is not re-configured.
  */
-public class JacksonJsonSerializer implements JsonSerializer{
+public class JacksonJsonSerializer implements JsonSerializer {
     /**
      * Represents the ObjectMapper used to serialize/de-serialize JSON.
-     *
+     * <p>
      * It will be initialized in a static initializer and will not change afterwards.
-     *
+     * <p>
      * Because ObjectMapper is thread-safe as long as it's not reconfigured, a static final class-level ObjectMapper is
      * used to achieve best performance.
      */
@@ -135,9 +135,9 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * Constructor.
-     *
+     * <p>
      * Parameters: None
-     *
+     * <p>
      * Exceptions: None
      */
     public JacksonJsonSerializer() {
@@ -145,13 +145,13 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * Serialize an object to JSON.
-     *
+     * <p>
      * Parameters:
      *   object : the object to serialize
      *   outputStream : the output stream to which the JSON will be written
-     *
+     * <p>
      * Returns: None
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -176,18 +176,18 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * Serialize an object to JSON.
-     *
+     * <p>
      * Parameters:
      *   object : the object to serialize
      *   outputStream : the output stream to which the JSON will be written
-     *
+     * <p>
      * Returns: None
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
-     * @return a string with the deserialized object
      * @param object the object to serialized
+     * @return a string with the deserialized object
      * @throws JSONSerializerException thrown for any serialization exception we catch
      */
     public <T> String serialize(T object) throws JSONSerializerException {
@@ -195,7 +195,7 @@ public class JacksonJsonSerializer implements JsonSerializer{
         String value;
 
         try {
-            value= OBJECT_MAPPER.writeValueAsString(object);
+            value = OBJECT_MAPPER.writeValueAsString(object);
         } catch (JsonGenerationException e) {
             throw new JSONSerializerException(e);
         } catch (JsonMappingException e) {
@@ -208,19 +208,15 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * De-serialize an object from JSON.
-     *
+     * <p>
      * Returns: the de-serialized object
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if any argument is null
      *   - JSONSerializerException : if there is any other error occurred during the operation
      *
      * @param inputStream the input stream from which the JSON will be read
      * @param objectClass the class of the object to de-serialize
-     * @return
-     * @throws IOException
-     * @throws JsonMappingException
-     * @throws JsonParseException
      */
     // @Override
     public <T> T deserialize(Class<T> objectClass, java.io.InputStream inputStream) throws IOException {
@@ -231,17 +227,15 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * De-serialize an object list from JSON.
-     *
+     * <p>
      * Returns: the de-serialized list
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if any argument is null
      *   - JSONSerializerException : if there is any other error occurred during the operation
      *
      * @param inputStream the input stream from which the JSON will be read
      * @param objectClass the class of the object (of the list) to de-serialize
-     * @return
-     * @throws JSONSerializerException
      */
     // @Override
     public <T> List<T> deserializeList(Class<T> objectClass, java.io.InputStream inputStream)
@@ -267,22 +261,24 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * De-serialize to a PagedResult (holds pagination info) from JSON
-     * @param objectClass
-     * @param inputStream
-     * @param <T>
-     * @return
-     * @throws JSONSerializerException
      */
     @Override
-    public <T> PagedResult<T> deserializeDataWrapper(Class<T> objectClass, java.io.InputStream inputStream) throws JSONSerializerException{
+    public <T> PagedResult<T> deserializeDataWrapper(
+            Class<T> objectClass,
+            java.io.InputStream inputStream
+    ) throws JSONSerializerException {
         Util.throwIfNull(objectClass, inputStream);
 
         PagedResult<T> rw = null;
 
         try {
             // Read the json input stream into a List.
-            rw = OBJECT_MAPPER.readValue(inputStream,
-                    OBJECT_MAPPER.getTypeFactory().constructParametrizedType(PagedResult.class, PagedResult.class, objectClass));
+            rw = OBJECT_MAPPER.readValue(
+                    inputStream,
+                    OBJECT_MAPPER
+                            .getTypeFactory()
+                            .constructParametrizedType(PagedResult.class, PagedResult.class, objectClass)
+            );
         } catch (JsonParseException e) {
             throw new JSONSerializerException(e);
         } catch (JsonMappingException e) {
@@ -296,10 +292,6 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * De-serialize to a map from JSON.
-     *
-     * @param inputStream
-     * @return
-     * @throws JSONSerializerException
      */
     // @Override
     public Map<String, Object> deserializeMap(InputStream inputStream) throws JSONSerializerException {
@@ -331,7 +323,6 @@ public class JacksonJsonSerializer implements JsonSerializer{
      * @param inputStream the input stream from which the JSON will be read
      * @param objectClass the class of the object (of the Result) to de-serialize
      * @return the de-serialized result
-     * @throws JSONSerializerException
      */
     // @Override
     public <T> Result<T> deserializeResult(Class<T> objectClass, java.io.InputStream inputStream)
@@ -367,8 +358,6 @@ public class JacksonJsonSerializer implements JsonSerializer{
      *
      * @param inputStream the input stream from which the JSON will be read
      * @param objectClass the class of the object (of the Result) to de-serialize
-     * @return
-     * @throws JSONSerializerException
      */
     // @Override
     public <T> Result<List<T>> deserializeListResult(Class<T> objectClass, java.io.InputStream inputStream)
@@ -411,12 +400,11 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * De-serialize to a CopyOrMoveRowResult object from JSON
-     * @param inputStream
-     * @return
-     * @throws JSONSerializerException
      */
     @Override
-    public CopyOrMoveRowResult deserializeCopyOrMoveRow(java.io.InputStream inputStream) throws JSONSerializerException{
+    public CopyOrMoveRowResult deserializeCopyOrMoveRow(
+            java.io.InputStream inputStream
+    ) throws JSONSerializerException {
         Util.throwIfNull(inputStream);
 
         CopyOrMoveRowResult rw = null;
@@ -437,12 +425,9 @@ public class JacksonJsonSerializer implements JsonSerializer{
 
     /**
      * De-serialize to a EventResult (holds pagination info) from JSON
-     * @param inputStream
-     * @return
-     * @throws JSONSerializerException
      */
     @Override
-    public EventResult deserializeEventResult(java.io.InputStream inputStream) throws JSONSerializerException{
+    public EventResult deserializeEventResult(java.io.InputStream inputStream) throws JSONSerializerException {
         Util.throwIfNull(inputStream);
 
         EventResult rw = null;

--- a/src/main/java/com/smartsheet/api/internal/json/JsonSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/JsonSerializer.java
@@ -20,7 +20,6 @@ package com.smartsheet.api.internal.json;
  * %[license]
  */
 
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.smartsheet.api.models.BulkItemResult;
@@ -36,19 +35,19 @@ import java.util.Map;
 
 /**
  * This interface defines methods to handle JSON serialization/de-serialization.
- *
+ * <p>
  * Thread Safety: Implementation of this interface must be thread safe.
  */
 public interface JsonSerializer {
 
     /**
      * Serialize an object to JSON.
-     *
+     * <p>
      * Parameters: - object : the object to serialize - outputStream : the output stream to which the JSON will be
      * written
-     *
+     * <p>
      * Returns: None
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -61,12 +60,12 @@ public interface JsonSerializer {
 
     /**
      * Serialize an object to JSON.
-     *
+     * <p>
      * Parameters: - object : the object to serialize - outputStream : the output stream to which the JSON will be
      * written
-     *
+     * <p>
      * Returns: None
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -82,18 +81,17 @@ public interface JsonSerializer {
      * @param inputStream the input stream
      * @param <T> the generic type
      * @return the PagedResult containing a list of type T
-     * @throws JSONSerializerException
      */
     <T> PagedResult<T> deserializeDataWrapper(Class<T> objectClass, java.io.InputStream inputStream) throws JSONSerializerException;
 
     /**
      * De-serialize an object from JSON.
-     *
+     * <p>
      * Parameters: - objectClass : the class of the object to de-serialize - inputStream : the input stream from which
      * the JSON will be read
-     *
+     * <p>
      * Returns: the de-serialized object
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -110,12 +108,12 @@ public interface JsonSerializer {
 
     /**
      * De-serialize an object list from JSON.
-     *
+     * <p>
      * Parameters: - objectClass : the class of the object (of the list) to de-serialize - inputStream : the input
      * stream from which the JSON will be read
-     *
+     * <p>
      * Returns: the de-serialized list
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -125,9 +123,7 @@ public interface JsonSerializer {
      * @return the list
      * @throws JSONSerializerException the JSON serializer exception
      */
-    <T> List<T> deserializeList(Class<T> objectClass, java.io.InputStream inputStream)
-            throws JSONSerializerException;
-
+    <T> List<T> deserializeList(Class<T> objectClass, java.io.InputStream inputStream) throws JSONSerializerException;
 
     /**
      * De-serialize an object list from JSON to a Map.
@@ -177,14 +173,15 @@ public interface JsonSerializer {
      */
     <T> Result<List<T>> deserializeListResult(Class<T> objectClass, java.io.InputStream inputStream)
             throws JSONSerializerException;
+
     /**
      * De-serialize a BulkItemResult object from JSON.
-     *
+     * <p>
      * Parameters:
      * - inputStream : the input stream from which the JSON will be read
-     *
+     * <p>
      * Returns: the de-serialized result
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -199,12 +196,12 @@ public interface JsonSerializer {
 
     /**
      * De-serialize a Result object from JSON.
-     *
+     * <p>
      * Parameters: - objectClass : the class of the object (of the Result) to de-serialize - inputStream : the input
      * stream from which the JSON will be read
-     *
+     * <p>
      * Returns: the de-serialized result
-     *
+     * <p>
      * Exceptions: - IllegalArgumentException : if any argument is null - JSONSerializerException : if there is any
      * other error occurred during the operation
      *
@@ -219,7 +216,6 @@ public interface JsonSerializer {
      * De-serialize json to EventResult.
      * @param inputStream the input stream
      * @return the EventResult containing a list of Event
-     * @throws JSONSerializerException
      */
     EventResult deserializeEventResult(java.io.InputStream inputStream)
             throws JSONSerializerException;

--- a/src/main/java/com/smartsheet/api/internal/json/ObjectValueDeserializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/ObjectValueDeserializer.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -92,15 +93,17 @@ public class ObjectValueDeserializer extends JsonDeserializer<ObjectValue> {
                     objectValue = contactObjectValue;
                     break;
 
-                case DATE:                // Intentional fallthrough
-                case DATETIME:            // Intentional fallthrough
+                case DATE:
+                    // Intentional fallthrough
+                case DATETIME:
+                    // Intentional fallthrough
                 case ABSTRACT_DATETIME:
                     objectValue = new DateObjectValue(parsedObjectType, superset.value);
                     break;
 
                 case MULTI_CONTACT:
                     List<ContactObjectValue> contactObjectValues = new ArrayList<>();
-                    for(Object contact: superset.values) {
+                    for (Object contact: superset.values) {
                         contactObjectValue = mapper.convertValue(contact, ContactObjectValue.class);
                         contactObjectValues.add(contactObjectValue);
                     }
@@ -108,7 +111,7 @@ public class ObjectValueDeserializer extends JsonDeserializer<ObjectValue> {
                     break;
 
                 case MULTI_PICKLIST:
-                    objectValue = new MultiPicklistObjectValue((List<String>)superset.values);
+                    objectValue = new MultiPicklistObjectValue((List<String>) superset.values);
                     break;
 
                 default:
@@ -128,7 +131,8 @@ public class ObjectValueDeserializer extends JsonDeserializer<ObjectValue> {
     }
 
     private static class ObjectValueAttributeSuperset {
-        public String objectType; // This needs to be represented as a string so that any new object types added won't completely break the API
+        // This needs to be represented as a string so that any new object types added won't completely break the API
+        public String objectType;
 
         // PREDECESSOR_LIST specific attributes
         public List<Predecessor> predecessors;

--- a/src/main/java/com/smartsheet/api/internal/json/PrimitiveObjectValueSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/PrimitiveObjectValueSerializer.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/smartsheet/api/internal/json/RecipientDeserializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/RecipientDeserializer.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,14 +38,13 @@ public class RecipientDeserializer extends JsonDeserializer<Recipient> {
     public Recipient deserialize(JsonParser jp, DeserializationContext ctxt)
             throws IOException, JsonProcessingException {
 
-        if(jp.getCurrentToken() == JsonToken.START_OBJECT) {
+        if (jp.getCurrentToken() == JsonToken.START_OBJECT) {
             JsonNode node = jp.getCodec().readTree(jp);
-            if(node.get("email") != null) {
+            if (node.get("email") != null) {
                 RecipientEmail email = new
                         RecipientEmail.AddRecipientEmailBuilder().setEmail(node.get("email").asText()).build();
                 return email;
-            }
-            else if(node.get("groupId") != null) {
+            } else if (node.get("groupId") != null) {
                 RecipientGroup group = new
                         RecipientGroup.AddRecipientGroupBuilder().setGroupId(node.get("groupId").asLong()).build();
                 return group;

--- a/src/main/java/com/smartsheet/api/internal/json/WidgetContentDeserializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/WidgetContentDeserializer.java
@@ -1,4 +1,5 @@
 package com.smartsheet.api.internal.json;
+
 /*
  * #[license]
  * Smartsheet SDK for Java
@@ -8,9 +9,9 @@ package com.smartsheet.api.internal.json;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,10 +75,9 @@ public class WidgetContentDeserializer extends JsonDeserializer<WidgetContent> {
         try {
             parsedType = WidgetType.valueOf(superset.type);
         } catch (IllegalArgumentException e) {
-            if(superset.type.equals("WidgetWebContent")) {
+            if (superset.type.equals("WidgetWebContent")) {
                 parsedType = WidgetType.WEBCONTENT;
-            }
-            else {
+            } else {
                 // If a new object type is introduced to the Smartsheet API that this version of the SDK
                 // doesn't support, return null instead of throwing an exception.
                 return null;
@@ -126,7 +126,8 @@ public class WidgetContentDeserializer extends JsonDeserializer<WidgetContent> {
                 widgetContent = reportWidgetContent;
                 break;
 
-            case RICHTEXT:            // Intentional fallthrough
+            case RICHTEXT:
+                // Intentional fallthrough
             case TITLE:
                 TitleRichTextWidgetContent titleRichTextWidgetContent = new TitleRichTextWidgetContent();
                 titleRichTextWidgetContent.setBackgroundColor(superset.backgroundColor);

--- a/src/main/java/com/smartsheet/api/internal/util/QueryUtil.java
+++ b/src/main/java/com/smartsheet/api/internal/util/QueryUtil.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal.util;
  * limitations under the License.
  * %[license]
  */
-
 
 import org.jetbrains.annotations.Nullable;
 
@@ -46,6 +45,9 @@ public class QueryUtil {
         return list.stream().map(Object::toString).collect(Collectors.joining(","));
     }
 
+    /**
+     * Generate a URL
+     */
     public static String generateUrl(@Nullable String baseUrl, @Nullable Map<String, ? extends Object> parameters) {
         if (baseUrl == null) {
             baseUrl = "";
@@ -64,7 +66,7 @@ public class QueryUtil {
             return "";
         }
         StringBuilder result = new StringBuilder();
-        for(Map.Entry<String, ? extends Object> entry : parameters.entrySet()) {
+        for (Map.Entry<String, ? extends Object> entry : parameters.entrySet()) {
             // Check to see if the key/value isn't null or empty string
             if (entry.getKey() != null && (entry.getValue() != null && !entry.getValue().toString().equals(""))) {
                 String encodedQueryParam = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8);

--- a/src/main/java/com/smartsheet/api/internal/util/StreamUtil.java
+++ b/src/main/java/com/smartsheet/api/internal/util/StreamUtil.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.internal.util;
  * limitations under the License.
  * %[license]
  */
-
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -68,9 +67,14 @@ public class StreamUtil {
      * @param bufferSize the size of the transfer buffer to use
      * @param readToEOF  if we should read to end-of-file of the source (true) or just 1 buffer's worth (false)
      */
-    public static long copyContentIntoOutputStream(InputStream source, OutputStream target, int bufferSize,
-                                                   boolean readToEOF) throws IOException {
-        byte[] tempBuf = new byte[Math.max(ONE_KB, bufferSize)];  // at least a 1k buffer
+    public static long copyContentIntoOutputStream(
+            InputStream source,
+            OutputStream target,
+            int bufferSize,
+            boolean readToEOF
+    ) throws IOException {
+        // at least a 1k buffer
+        byte[] tempBuf = new byte[Math.max(ONE_KB, bufferSize)];
         long bytesWritten = 0;
         while (true) {
             int bytesRead = source.read(tempBuf);
@@ -102,7 +106,8 @@ public class StreamUtil {
         }
         // if the source supports mark/reset then we read and then reset up to the read-back size
         if (source.markSupported()) {
-            readbackSize = Math.max(TEN_KB, readbackSize);  // at least 10 KB (minimal waste, handles those -1 ContentLength cases)
+            // at least 10 KB (minimal waste, handles those -1 ContentLength cases)
+            readbackSize = Math.max(TEN_KB, readbackSize);
             source.mark(readbackSize);
             copyContentIntoOutputStream(source, target, readbackSize, false);
             source.reset();
@@ -117,7 +122,7 @@ public class StreamUtil {
 
     /** a convenience method to reduce all the casting of HttpEntity.getContentLength() to int */
     public static InputStream cloneContent(InputStream source, long readbackSize, ByteArrayOutputStream target) throws IOException {
-        return cloneContent(source, (int)Math.min((long)Integer.MAX_VALUE, readbackSize), target);
+        return cloneContent(source, (int) Math.min((long) Integer.MAX_VALUE, readbackSize), target);
     }
 
     /**

--- a/src/main/java/com/smartsheet/api/internal/util/Util.java
+++ b/src/main/java/com/smartsheet/api/internal/util/Util.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.internal.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ public class Util {
 
     /** faster util method that avoids creation of array for single-arg cases */
     public static <T> T throwIfNull(T obj) {
-        if(obj == null){
+        if (obj == null) {
             throw new IllegalArgumentException();
         }
         return obj;
@@ -34,10 +34,10 @@ public class Util {
 
     /** faster util method that avoids creation of array for two-arg cases */
     public static void throwIfNull(Object obj1, Object obj2) {
-        if(obj1 == null){
+        if (obj1 == null) {
             throw new IllegalArgumentException();
         }
-        if(obj2 == null){
+        if (obj2 == null) {
             throw new IllegalArgumentException();
         }
     }
@@ -52,14 +52,17 @@ public class Util {
         }
     }
 
-
     /** faster util method that avoids creation of array for single-arg cases */
     public static void throwIfEmpty(String string) {
-        if(string != null && string.isEmpty()){ // FIXME - so... null isn't empty?
+        // FIXME - so... null isn't empty?
+        if (string != null && string.isEmpty()) {
             throw new IllegalArgumentException();
         }
     }
 
+    /**
+     * Throw an exception if any of the strings are empty
+     */
     public static void throwIfEmpty(String... strings) {
         for (String string : strings) {
             throwIfEmpty(string);

--- a/src/main/java/com/smartsheet/api/models/enums/FolderCopyInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/FolderCopyInclusion.java
@@ -38,7 +38,9 @@ public enum FolderCopyInclusion {
 
     String inclusion;
 
-    FolderCopyInclusion(String inclusion) { this.inclusion = inclusion;}
+    FolderCopyInclusion(String inclusion) {
+        this.inclusion = inclusion;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/smartsheet/api/models/enums/SheetCopyInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/SheetCopyInclusion.java
@@ -33,11 +33,14 @@ public enum SheetCopyInclusion {
     RULERECIPIENTS("ruleRecipients"),
     RULES("rules"),
     SHARES("shares"),
-    ALL("all");    // deprecated
+    // All is deprecated
+    ALL("all");
 
     String inclusion;
 
-    SheetCopyInclusion(String inclusion) { this.inclusion = inclusion;}
+    SheetCopyInclusion(String inclusion) {
+        this.inclusion = inclusion;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/smartsheet/api/models/enums/SheetTemplateInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/SheetTemplateInclusion.java
@@ -44,5 +44,3 @@ public enum SheetTemplateInclusion {
         return inclusion;
     }
 }
-
-

--- a/src/main/java/com/smartsheet/api/models/enums/WorkspaceCopyInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/WorkspaceCopyInclusion.java
@@ -39,7 +39,9 @@ public enum WorkspaceCopyInclusion {
 
     String inclusion;
 
-    WorkspaceCopyInclusion(String inclusion) { this.inclusion = inclusion;}
+    WorkspaceCopyInclusion(String inclusion) {
+        this.inclusion = inclusion;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/smartsheet/api/models/format/Underline.java
+++ b/src/main/java/com/smartsheet/api/models/format/Underline.java
@@ -29,7 +29,7 @@ public enum Underline {
     ;
     private final boolean underlined;
 
-    Underline (boolean underlined) {
+    Underline(boolean underlined) {
         this.underlined = underlined;
     }
 

--- a/src/main/java/com/smartsheet/api/oauth/AccessScope.java
+++ b/src/main/java/com/smartsheet/api/oauth/AccessScope.java
@@ -60,6 +60,7 @@ public enum AccessScope {
     WRITE_SHEETS("WRITE_SHEETS");
 
     String scope;
+
     AccessScope(String scope) {
         this.scope = scope;
     }

--- a/src/main/java/com/smartsheet/api/oauth/AuthorizationResult.java
+++ b/src/main/java/com/smartsheet/api/oauth/AuthorizationResult.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 /**
  * Represents an OAuth authorization result.

--- a/src/main/java/com/smartsheet/api/oauth/InvalidOAuthClientException.java
+++ b/src/main/java/com/smartsheet/api/oauth/InvalidOAuthClientException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,10 @@ package com.smartsheet.api.oauth;
  * %[license]
  */
 
-
-
 /**
- * <p>This is the exception thrown by {@link OAuthFlow} to indicate an "invalid_client" error occurred when obtaining 
+ * <p>This is the exception thrown by {@link OAuthFlow} to indicate an "invalid_client" error occurred when obtaining
  * OAuth tokens.</p>
- * 
+ *
  * <p>Thread safety: Exceptions are not thread safe.</p>
  */
 public class InvalidOAuthClientException extends OAuthTokenException {

--- a/src/main/java/com/smartsheet/api/oauth/InvalidOAuthGrantException.java
+++ b/src/main/java/com/smartsheet/api/oauth/InvalidOAuthGrantException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,6 @@ package com.smartsheet.api.oauth;
  * %[license]
  */
 
-
-
 /**
  * <p>This is the exception thrown by {@link OAuthFlow} to indicate an "invalid_grant" error occurred when obtaining
  * OAuth tokens.</p>
@@ -29,9 +27,6 @@ package com.smartsheet.api.oauth;
  * <p>Thread safety: Exceptions are not thread safe.</p>
  */
 public class InvalidOAuthGrantException extends OAuthTokenException {
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
 
     /**

--- a/src/main/java/com/smartsheet/api/oauth/InvalidScopeException.java
+++ b/src/main/java/com/smartsheet/api/oauth/InvalidScopeException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 /**
  * <p>This is the exception thrown by {@link OAuthFlow} to indicate an "invalid_scope" error occurred when obtaining an

--- a/src/main/java/com/smartsheet/api/oauth/InvalidTokenRequestException.java
+++ b/src/main/java/com/smartsheet/api/oauth/InvalidTokenRequestException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 /**
  * <p>This is the exception thrown by {@link OAuthFlow} to indicate an "invalid_request" error occurred when obtaining OAuth

--- a/src/main/java/com/smartsheet/api/oauth/OAuthAuthorizationCodeException.java
+++ b/src/main/java/com/smartsheet/api/oauth/OAuthAuthorizationCodeException.java
@@ -28,9 +28,6 @@ import com.smartsheet.api.SmartsheetException;
  * <p>Thread safety: Exceptions are not thread safe.</p>
  */
 public class OAuthAuthorizationCodeException extends SmartsheetException {
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
 
     /**

--- a/src/main/java/com/smartsheet/api/oauth/OAuthFlow.java
+++ b/src/main/java/com/smartsheet/api/oauth/OAuthFlow.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
 
 import com.smartsheet.api.InvalidRequestException;
 import com.smartsheet.api.internal.http.HttpClientException;
@@ -40,7 +39,7 @@ public interface OAuthFlow {
      *
      * @param scopes the requested scopes
      * @param state an arbitrary string that will be returned to your app; intended to be used by you to ensure that
-     * this redirect is indeed from an OAuth flow that you initiated.
+     *     this redirect is indeed from an OAuth flow that you initiated.
      * @return the authorization URL
      * @throws IllegalArgumentException if scopes is null or empty
      */
@@ -60,8 +59,11 @@ public interface OAuthFlow {
      * @throws IllegalArgumentException if any other error occurred during the operation
      */
     AuthorizationResult extractAuthorizationResult(String authorizationResponseURL) throws
-        URISyntaxException, AccessDeniedException, UnsupportedResponseTypeException, InvalidScopeException,
-        OAuthAuthorizationCodeException;
+            URISyntaxException,
+            AccessDeniedException,
+            UnsupportedResponseTypeException,
+            InvalidScopeException,
+            OAuthAuthorizationCodeException;
 
     /**
      * Obtain a new token using AuthorizationResult.
@@ -75,7 +77,12 @@ public interface OAuthFlow {
      * @throws InvalidRequestException the invalid request exception
      * @throws IllegalArgumentException if any other error occurred during the operation
      */
-    Token obtainNewToken(AuthorizationResult authorizationResult) throws OAuthTokenException, JSONSerializerException, HttpClientException, URISyntaxException, InvalidRequestException;
+    Token obtainNewToken(AuthorizationResult authorizationResult) throws
+            OAuthTokenException,
+            JSONSerializerException,
+            HttpClientException,
+            URISyntaxException,
+            InvalidRequestException;
 
     /**
      * Refresh token.
@@ -89,11 +96,16 @@ public interface OAuthFlow {
      * @throws InvalidRequestException the invalid request exception
      * @throws IllegalArgumentException if any other error occurred during the operation
      */
-    Token refreshToken(Token token) throws OAuthTokenException, JSONSerializerException, HttpClientException, URISyntaxException, InvalidRequestException;
+    Token refreshToken(Token token) throws
+            OAuthTokenException,
+            JSONSerializerException,
+            HttpClientException,
+            URISyntaxException,
+            InvalidRequestException;
 
     /**
      * Revoke access token.
-     *
+     * <p>
      * Exceptions:
      *   - IllegalArgumentException : if url is null or empty
      *   - InvalidTokenRequestException : if the token request is invalid

--- a/src/main/java/com/smartsheet/api/oauth/OAuthFlowBuilder.java
+++ b/src/main/java/com/smartsheet/api/oauth/OAuthFlowBuilder.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.internal.http.DefaultHttpClient;
 import com.smartsheet.api.internal.http.HttpClient;
@@ -290,23 +288,23 @@ public class OAuthFlowBuilder {
      * @throws IllegalArgumentException if clientId, clientSecret or redirectURL isn't set yet.
      */
     public OAuthFlow build() {
-        if(httpClient == null){
+        if (httpClient == null) {
             httpClient = new DefaultHttpClient();
         }
 
-        if(tokenURL == null){
+        if (tokenURL == null) {
             tokenURL = DEFAULT_TOKEN_URL;
         }
 
-        if(authorizationURL == null){
+        if (authorizationURL == null) {
             authorizationURL = DEFAULT_AUTHORIZATION_URL;
         }
 
-        if(jsonSerializer == null){
+        if (jsonSerializer == null) {
             jsonSerializer = new JacksonJsonSerializer();
         }
 
-        if(clientId == null || clientSecret == null || redirectURL == null){
+        if (clientId == null || clientSecret == null || redirectURL == null) {
             throw new IllegalStateException();
         }
 

--- a/src/main/java/com/smartsheet/api/oauth/OAuthTokenException.java
+++ b/src/main/java/com/smartsheet/api/oauth/OAuthTokenException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 import com.smartsheet.api.SmartsheetException;
 

--- a/src/main/java/com/smartsheet/api/oauth/Token.java
+++ b/src/main/java/com/smartsheet/api/oauth/Token.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 /**
  * Represents OAuth token.

--- a/src/main/java/com/smartsheet/api/oauth/UnsupportedOAuthGrantTypeException.java
+++ b/src/main/java/com/smartsheet/api/oauth/UnsupportedOAuthGrantTypeException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
 
 /**
  * <p>This is the exception thrown by {@link OAuthFlow} to indicate "unsupported_grant_type" error occurred during obtaining OAuth

--- a/src/main/java/com/smartsheet/api/oauth/UnsupportedResponseTypeException.java
+++ b/src/main/java/com/smartsheet/api/oauth/UnsupportedResponseTypeException.java
@@ -9,9 +9,9 @@ package com.smartsheet.api.oauth;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@ package com.smartsheet.api.oauth;
  * limitations under the License.
  * %[license]
  */
-
-
 
 /**
  * <p>This is the exception thrown by {@link OAuthFlow} to indicate "unsupported_response_type" error occurred when obtaining


### PR DESCRIPTION
We are now down to `20` checkstyle violations in main and `0` violations in test.

The remaining 20 violations are not trivial to fix, so I've set checkstyle to allow those 20 violations to exist, but to fail the build if we ever exceed 20 violations. This should make the build fail if any new violations are added.

For tests, we do not allow _any_ violations. This means adding a single violation will fail the build. Once the 20 violations in main are cleaned up, we can make main and test have the same config.

Note: This MR also changes our PR pipeline to run `./gradlew clean build` instead of `./gradlew clean test`. The reason for this is that build runs all the tests and performs all the other checks (such as checkstyle), whereas `test` didn't run checkstyle and we wouldn't have noticed violations until we tried to deploy.