### PR TITLE
Add tests for the model/enums classes

### DIFF
--- a/src/test/java/com/smartsheet/api/models/enums/AutomationActionFrequencyTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/AutomationActionFrequencyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models.enums;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutomationActionFrequencyTest {
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ToStringTests {
+        @Nested
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        class ValueOfTests {
+            @ParameterizedTest
+            @MethodSource("valuesArguments")
+            void valueOf(AutomationActionFrequency expectedAutomationActionFrequency, String value) {
+                // Act
+                AutomationActionFrequency result = AutomationActionFrequency.valueOf(value);
+
+                // Assert
+                assertThat(result).isEqualTo(expectedAutomationActionFrequency);
+
+                // This will cause the test to fail if we ever add a new value.
+                // Please remember to add the new value in the method below
+                assertThat(AutomationActionFrequency.values()).hasSize(4);
+            }
+
+            private Stream<Arguments> valuesArguments() {
+                return Stream.of(
+                        Arguments.of(AutomationActionFrequency.IMMEDIATELY, "IMMEDIATELY"),
+                        Arguments.of(AutomationActionFrequency.HOURLY, "HOURLY"),
+                        Arguments.of(AutomationActionFrequency.DAILY, "DAILY"),
+                        Arguments.of(AutomationActionFrequency.WEEKLY, "WEEKLY")
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/com/smartsheet/api/models/enums/AutomationActionTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/AutomationActionTypeTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,29 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class AutomationActionTypeTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class ToStringTests {
+    class ValueOfTests {
         @ParameterizedTest
-        @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        @MethodSource("valuesArguments")
+        void valueOf(AutomationActionType expectedAutomationActionType, String value) {
             // Act
-            String result = objectInclusion.toString();
+            AutomationActionType result = AutomationActionType.valueOf(value);
 
             // Assert
-            assertThat(result).isEqualTo(expectedString);
+            assertThat(result).isEqualTo(expectedAutomationActionType);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(AutomationActionType.values()).hasSize(3);
         }
 
-        private Stream<Arguments> toStringArguments() {
+        private Stream<Arguments> valuesArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(AutomationActionType.NOTIFICATION_ACTION, "NOTIFICATION_ACTION"),
+                    Arguments.of(AutomationActionType.UPDATE_REQUEST_ACTION, "UPDATE_REQUEST_ACTION"),
+                    Arguments.of(AutomationActionType.APPROVAL_REQUEST_ACTION, "APPROVAL_REQUEST_ACTION")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/AutomationRuleDisabledReasonTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/AutomationRuleDisabledReasonTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models.enums;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutomationRuleDisabledReasonTest {
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ValueOfTests {
+        @ParameterizedTest
+        @MethodSource("valuesArguments")
+        void valueOf(AutomationRuleDisabledReason expectedAutomationRuleDisabledReason, String value) {
+            // Act
+            AutomationRuleDisabledReason result = AutomationRuleDisabledReason.valueOf(value);
+
+            // Assert
+            assertThat(result).isEqualTo(expectedAutomationRuleDisabledReason);
+
+            // This will cause the test to fail if we ever add a new value.
+            // Please remember to add the new value in the method below
+            assertThat(AutomationRuleDisabledReason.values()).hasSize(7);
+        }
+
+        private Stream<Arguments> valuesArguments() {
+            return Stream.of(
+                    Arguments.of(AutomationRuleDisabledReason.AUTOMATION_NOT_ENABLED_FOR_ORG, "AUTOMATION_NOT_ENABLED_FOR_ORG"),
+                    Arguments.of(AutomationRuleDisabledReason.COLUMN_MISSING, "COLUMN_MISSING"),
+                    Arguments.of(AutomationRuleDisabledReason.COLUMN_TYPE_INCOMPATIBLE, "COLUMN_TYPE_INCOMPATIBLE"),
+                    Arguments.of(AutomationRuleDisabledReason.NO_POTENTIAL_RECIPIENTS, "NO_POTENTIAL_RECIPIENTS"),
+                    Arguments.of(AutomationRuleDisabledReason.NO_VALID_SELECTED_COLUMNS, "NO_VALID_SELECTED_COLUMNS"),
+                    Arguments.of(AutomationRuleDisabledReason.APPROVAL_COLUMN_MISSING, "APPROVAL_COLUMN_MISSING"),
+                    Arguments.of(AutomationRuleDisabledReason.APPROVAL_COLUMN_WRONG_TYPE, "APPROVAL_COLUMN_WRONG_TYPE")
+            );
+        }
+    }
+}

--- a/src/test/java/com/smartsheet/api/models/enums/CellHistoryInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/CellHistoryInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,29 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class CellHistoryInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(CellHistoryInclusion cellHistoryInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = cellHistoryInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(CellHistoryInclusion.values()).hasSize(3);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(CellHistoryInclusion.COLUMN_TYPE, "columnType"),
+                    Arguments.of(CellHistoryInclusion.FORMAT, "format"),
+                    Arguments.of(CellHistoryInclusion.OBJECT_VALUE, "objectValue")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/CopyExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/CopyExclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class CopyExclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(CopyExclusion copyExclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = copyExclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(CopyExclusion.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(CopyExclusion.SHEET_HYPERLINKS, "sheetHyperlinks")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/EventActionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/EventActionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2023 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models.enums;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventActionTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ValueOfTests {
+        @ParameterizedTest
+        @MethodSource("valuesArguments")
+        void valueOf(EventAction expectedEventAction, String value) {
+            // Act
+            EventAction result = EventAction.valueOf(value);
+
+            // Assert
+            assertThat(result).isEqualTo(expectedEventAction);
+
+            // This will cause the test to fail if we ever add a new value.
+            // Please remember to add the new value in the method below
+            assertThat(EventAction.values()).hasSize(55);
+        }
+
+        private Stream<Arguments> valuesArguments() {
+            return Stream.of(
+                    Arguments.of(EventAction.CREATE, "CREATE"),
+                    Arguments.of(EventAction.UPDATE, "UPDATE"),
+                    Arguments.of(EventAction.LOAD, "LOAD"),
+                    Arguments.of(EventAction.DELETE, "DELETE"),
+                    Arguments.of(EventAction.PURGE, "PURGE"),
+                    Arguments.of(EventAction.RESTORE, "RESTORE"),
+                    Arguments.of(EventAction.RENAME, "RENAME"),
+                    Arguments.of(EventAction.ACTIVATE, "ACTIVATE"),
+                    Arguments.of(EventAction.DEACTIVATE, "DEACTIVATE"),
+                    Arguments.of(EventAction.EXPORT, "EXPORT"),
+                    Arguments.of(EventAction.MOVE, "MOVE"),
+                    Arguments.of(EventAction.MOVE_ROW, "MOVE_ROW"),
+                    Arguments.of(EventAction.COPY_ROW, "COPY_ROW"),
+                    Arguments.of(EventAction.SAVE_AS_NEW, "SAVE_AS_NEW"),
+                    Arguments.of(EventAction.SAVE_AS_TEMPLATE, "SAVE_AS_TEMPLATE"),
+                    Arguments.of(EventAction.ADD_PUBLISH, "ADD_PUBLISH"),
+                    Arguments.of(EventAction.REMOVE_PUBLISH, "REMOVE_PUBLISH"),
+                    Arguments.of(EventAction.ADD_SHARE, "ADD_SHARE"),
+                    Arguments.of(EventAction.REMOVE_SHARE, "REMOVE_SHARE"),
+                    Arguments.of(EventAction.ADD_SHARE_MEMBER, "ADD_SHARE_MEMBER"),
+                    Arguments.of(EventAction.REMOVE_SHARE_MEMBER, "REMOVE_SHARE_MEMBER"),
+                    Arguments.of(EventAction.ADD_WORKSPACE_SHARE, "ADD_WORKSPACE_SHARE"),
+                    Arguments.of(EventAction.REMOVE_WORKSPACE_SHARE, "REMOVE_WORKSPACE_SHARE"),
+                    Arguments.of(EventAction.ADD_MEMBER, "ADD_MEMBER"),
+                    Arguments.of(EventAction.REMOVE_MEMBER, "REMOVE_MEMBER"),
+                    Arguments.of(EventAction.TRANSFER_OWNERSHIP, "TRANSFER_OWNERSHIP"),
+                    Arguments.of(EventAction.CREATE_CELL_LINK, "CREATE_CELL_LINK"),
+                    Arguments.of(EventAction.REMOVE_SHARES, "REMOVE_SHARES"),
+                    Arguments.of(EventAction.TRANSFER_OWNED_GROUPS, "TRANSFER_OWNED_GROUPS"),
+                    Arguments.of(EventAction.TRANSFER_OWNED_ITEMS, "TRANSFER_OWNED_ITEMS"),
+                    Arguments.of(EventAction.DOWNLOAD_SHEET_ACCESS_REPORT, "DOWNLOAD_SHEET_ACCESS_REPORT"),
+                    Arguments.of(EventAction.DOWNLOAD_USER_LIST, "DOWNLOAD_USER_LIST"),
+                    Arguments.of(EventAction.DOWNLOAD_LOGIN_HISTORY, "DOWNLOAD_LOGIN_HISTORY"),
+                    Arguments.of(EventAction.DOWNLOAD_PUBLISHED_ITEMS_REPORT, "DOWNLOAD_PUBLISHED_ITEMS_REPORT"),
+                    Arguments.of(EventAction.UPDATE_MAIN_CONTACT, "UPDATE_MAIN_CONTACT"),
+                    Arguments.of(EventAction.IMPORT_USERS, "IMPORT_USERS"),
+                    Arguments.of(EventAction.BULK_UPDATE, "BULK_UPDATE"),
+                    Arguments.of(EventAction.LIST_SHEETS, "LIST_SHEETS"),
+                    Arguments.of(EventAction.REQUEST_BACKUP, "REQUEST_BACKUP"),
+                    Arguments.of(EventAction.CREATE_RECURRING_BACKUP, "CREATE_RECURRING_BACKUP"),
+                    Arguments.of(EventAction.UPDATE_RECURRING_BACKUP, "UPDATE_RECURRING_BACKUP"),
+                    Arguments.of(EventAction.DELETE_RECURRING_BACKUP, "DELETE_RECURRING_BACKUP"),
+                    Arguments.of(EventAction.REMOVE_FROM_GROUPS, "REMOVE_FROM_GROUPS"),
+                    Arguments.of(EventAction.SEND_AS_ATTACHMENT, "SEND_AS_ATTACHMENT"),
+                    Arguments.of(EventAction.SEND_ROW, "SEND_ROW"),
+                    Arguments.of(EventAction.SEND, "SEND"),
+                    Arguments.of(EventAction.SEND_COMMENT, "SEND_COMMENT"),
+                    Arguments.of(EventAction.SEND_INVITE, "SEND_INVITE"),
+                    Arguments.of(EventAction.DECLINE_INVITE, "DECLINE_INVITE"),
+                    Arguments.of(EventAction.ACCEPT_INVITE, "ACCEPT_INVITE"),
+                    Arguments.of(EventAction.SEND_PASSWORD_RESET, "SEND_PASSWORD_RESET"),
+                    Arguments.of(EventAction.REMOVE_FROM_ACCOUNT, "REMOVE_FROM_ACCOUNT"),
+                    Arguments.of(EventAction.ADD_TO_ACCOUNT, "ADD_TO_ACCOUNT"),
+                    Arguments.of(EventAction.AUTHORIZE, "AUTHORIZE"),
+                    Arguments.of(EventAction.REVOKE, "REVOKE")
+            );
+        }
+    }
+}

--- a/src/test/java/com/smartsheet/api/models/enums/EventObjectTypeTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/EventObjectTypeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models.enums;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventObjectTypeTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ValueOfTests {
+        @ParameterizedTest
+        @MethodSource("valuesArguments")
+        void valueOf(EventObjectType expectedEventObjectType, String value) {
+            // Act
+            EventObjectType result = EventObjectType.valueOf(value);
+
+            // Assert
+            assertThat(result).isEqualTo(expectedEventObjectType);
+
+            // This will cause the test to fail if we ever add a new value.
+            // Please remember to add the new value in the method below
+            assertThat(EventObjectType.values()).hasSize(13);
+        }
+
+        private Stream<Arguments> valuesArguments() {
+            return Stream.of(
+                    Arguments.of(EventObjectType.ACCESS_TOKEN, "ACCESS_TOKEN"),
+                    Arguments.of(EventObjectType.ACCOUNT, "ACCOUNT"),
+                    Arguments.of(EventObjectType.ATTACHMENT, "ATTACHMENT"),
+                    Arguments.of(EventObjectType.DASHBOARD, "DASHBOARD"),
+                    Arguments.of(EventObjectType.DISCUSSION, "DISCUSSION"),
+                    Arguments.of(EventObjectType.FOLDER, "FOLDER"),
+                    Arguments.of(EventObjectType.FORM, "FORM"),
+                    Arguments.of(EventObjectType.GROUP, "GROUP"),
+                    Arguments.of(EventObjectType.SHEET, "SHEET"),
+                    Arguments.of(EventObjectType.REPORT, "REPORT"),
+                    Arguments.of(EventObjectType.UPDATE_REQUEST, "UPDATE_REQUEST"),
+                    Arguments.of(EventObjectType.USER, "USER"),
+                    Arguments.of(EventObjectType.WORKSPACE, "WORKSPACE")
+            );
+        }
+    }
+
+}

--- a/src/test/java/com/smartsheet/api/models/enums/EventSourceTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/EventSourceTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,32 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class EventSourceTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class ToStringTests {
+    class ValueOfTests {
         @ParameterizedTest
-        @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        @MethodSource("valuesArguments")
+        void valueOf(EventSource expectedEventSource, String value) {
             // Act
-            String result = objectInclusion.toString();
+            EventSource result = EventSource.valueOf(value);
 
             // Assert
-            assertThat(result).isEqualTo(expectedString);
+            assertThat(result).isEqualTo(expectedEventSource);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(EventSource.values()).hasSize(6);
         }
 
-        private Stream<Arguments> toStringArguments() {
+        private Stream<Arguments> valuesArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(EventSource.WEB_APP, "WEB_APP"),
+                    Arguments.of(EventSource.MOBILE_IOS, "MOBILE_IOS"),
+                    Arguments.of(EventSource.MOBILE_ANDROID, "MOBILE_ANDROID"),
+                    Arguments.of(EventSource.API_INTEGRATED_APP, "API_INTEGRATED_APP"),
+                    Arguments.of(EventSource.API_UNDEFINED_APP, "API_UNDEFINED_APP"),
+                    Arguments.of(EventSource.UNKNOWN, "UNKNOWN")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/FolderCopyInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/FolderCopyInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,36 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class FolderCopyInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(FolderCopyInclusion fieldCopyInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = fieldCopyInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(FolderCopyInclusion.values()).hasSize(10);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(FolderCopyInclusion.ATTACHMENTS, "attachments"),
+                    Arguments.of(FolderCopyInclusion.CELLLINKS, "cellLinks"),
+                    Arguments.of(FolderCopyInclusion.DATA, "data"),
+                    Arguments.of(FolderCopyInclusion.DISCUSSIONS, "discussions"),
+                    Arguments.of(FolderCopyInclusion.FILTERS, "filters"),
+                    Arguments.of(FolderCopyInclusion.FORMS, "forms"),
+                    Arguments.of(FolderCopyInclusion.RULERECIPIENTS, "ruleRecipients"),
+                    Arguments.of(FolderCopyInclusion.RULES, "rules"),
+                    Arguments.of(FolderCopyInclusion.SHARES, "shares"),
+                    Arguments.of(FolderCopyInclusion.ALL, "all")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/FolderRemapExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/FolderRemapExclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,30 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class FolderRemapExclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(FolderRemapExclusion folderRemapExclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = folderRemapExclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(FolderRemapExclusion.values()).hasSize(4);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(FolderRemapExclusion.CELLLINKS, "cellLinks"),
+                    Arguments.of(FolderRemapExclusion.REPORTS, "reports"),
+                    Arguments.of(FolderRemapExclusion.SHEETHYPERLINKS, "sheetHyperlinks"),
+                    Arguments.of(FolderRemapExclusion.SIGHTS, "sights")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/ListUserInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/ListUserInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class ListUserInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(ListUserInclusion listUserInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = listUserInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(ListUserInclusion.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(ListUserInclusion.LAST_LOGIN, "lastLogin")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SearchInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SearchInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SearchInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SearchInclusion searchInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = searchInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SearchInclusion.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SearchInclusion.FAVORITE_FLAG, "favoriteFlag")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SearchLocationTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SearchLocationTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SearchLocationTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SearchLocation searchLocation, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = searchLocation.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SearchLocation.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SearchLocation.PERSONAL_WORKSPACE, "personalWorkspace")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SearchScopeTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SearchScopeTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,36 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SearchScopeTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SearchScope searchScope, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = searchScope.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SearchScope.values()).hasSize(10);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SearchScope.ATTACHMENTS, "attachments"),
+                    Arguments.of(SearchScope.CELL_DATA, "cellData"),
+                    Arguments.of(SearchScope.COMMENTS, "comments"),
+                    Arguments.of(SearchScope.FOLDER_NAMES, "folderNames"),
+                    Arguments.of(SearchScope.REPORT_NAMES, "reportNames"),
+                    Arguments.of(SearchScope.SHEET_NAMES, "sheetNames"),
+                    Arguments.of(SearchScope.SIGHT_NAMES, "sightNames"),
+                    Arguments.of(SearchScope.SUMMARY_FIELDS, "summaryFields"),
+                    Arguments.of(SearchScope.TEMPLATE_NAMES, "templateNames"),
+                    Arguments.of(SearchScope.WORKSPACE_NAMES, "workspaceNames")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SheetCopyInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SheetCopyInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,36 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SheetCopyInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SheetCopyInclusion sheetCopyInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = sheetCopyInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SheetCopyInclusion.values()).hasSize(10);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SheetCopyInclusion.ATTACHMENTS, "attachments"),
+                    Arguments.of(SheetCopyInclusion.CELLLINKS, "cellLinks"),
+                    Arguments.of(SheetCopyInclusion.DATA, "data"),
+                    Arguments.of(SheetCopyInclusion.DISCUSSIONS, "discussions"),
+                    Arguments.of(SheetCopyInclusion.FILTERS, "filters"),
+                    Arguments.of(SheetCopyInclusion.FORMS, "forms"),
+                    Arguments.of(SheetCopyInclusion.RULERECIPIENTS, "ruleRecipients"),
+                    Arguments.of(SheetCopyInclusion.RULES, "rules"),
+                    Arguments.of(SheetCopyInclusion.SHARES, "shares"),
+                    Arguments.of(SheetCopyInclusion.ALL, "all")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SightInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SightInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SightInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SightInclusion sightInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = sightInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SightInclusion.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SightInclusion.SOURCE, "source")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SourceExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SourceExclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SourceExclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SourceExclusion sourceExclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = sourceExclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SourceExclusion.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SourceExclusion.PERMALINKS, "permalinks")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SummaryFieldExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SummaryFieldExclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,29 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SummaryFieldExclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SummaryFieldExclusion summaryFieldExclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = summaryFieldExclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SummaryFieldExclusion.values()).hasSize(3);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SummaryFieldExclusion.DISPLAYVALUE, "displayValue"),
+                    Arguments.of(SummaryFieldExclusion.IMAGE, "Image"),
+                    Arguments.of(SummaryFieldExclusion.IMAGEALTTEXT, "imageAltText")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/SummaryFieldInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/SummaryFieldInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,28 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class SummaryFieldInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(SummaryFieldInclusion summaryFieldInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = summaryFieldInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(SummaryFieldInclusion.values()).hasSize(2);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(SummaryFieldInclusion.FORMAT, "format"),
+                    Arguments.of(SummaryFieldInclusion.WRITERINFO, "writerInfo")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/UpdateRequestStatusTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/UpdateRequestStatusTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,29 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class UpdateRequestStatusTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class ToStringTests {
+    class ValueOfTests {
         @ParameterizedTest
-        @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        @MethodSource("valuesArguments")
+        void valueOf(UpdateRequestStatus expectedUpdateRequestStatus, String value) {
             // Act
-            String result = objectInclusion.toString();
+            UpdateRequestStatus result = UpdateRequestStatus.valueOf(value);
 
             // Assert
-            assertThat(result).isEqualTo(expectedString);
+            assertThat(result).isEqualTo(expectedUpdateRequestStatus);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(UpdateRequestStatus.values()).hasSize(3);
         }
 
-        private Stream<Arguments> toStringArguments() {
+        private Stream<Arguments> valuesArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(UpdateRequestStatus.PENDING, "PENDING"),
+                    Arguments.of(UpdateRequestStatus.CANCELED, "CANCELED"),
+                    Arguments.of(UpdateRequestStatus.COMPLETE, "COMPLETE")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/UserInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/UserInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,27 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class UserInclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(UserInclusion userInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = userInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(UserInclusion.values()).hasSize(1);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(UserInclusion.GROUPS, "groups")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/WebhookStatusTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/WebhookStatusTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,34 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class WebhookStatusTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class ToStringTests {
+    class ValueOfTests {
         @ParameterizedTest
-        @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        @MethodSource("valuesArguments")
+        void valueOf(WebhookStatus expectedWebhookStatus, String value) {
             // Act
-            String result = objectInclusion.toString();
+            WebhookStatus result = WebhookStatus.valueOf(value);
 
             // Assert
-            assertThat(result).isEqualTo(expectedString);
+            assertThat(result).isEqualTo(expectedWebhookStatus);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(WebhookStatus.values()).hasSize(8);
         }
 
-        private Stream<Arguments> toStringArguments() {
+        private Stream<Arguments> valuesArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(WebhookStatus.ENABLED, "ENABLED"),
+                    Arguments.of(WebhookStatus.NEW_NOT_VERIFIED, "NEW_NOT_VERIFIED"),
+                    Arguments.of(WebhookStatus.DISABLED_BY_OWNER, "DISABLED_BY_OWNER"),
+                    Arguments.of(WebhookStatus.DISABLED_VERIFICATION_FAILED, "DISABLED_VERIFICATION_FAILED"),
+                    Arguments.of(WebhookStatus.DISABLED_CALLBACK_FAILED, "DISABLED_CALLBACK_FAILED"),
+                    Arguments.of(WebhookStatus.DISABLED_APP_REVOKED, "DISABLED_APP_REVOKED"),
+                    Arguments.of(WebhookStatus.DISABLED_SCOPE_INACCESSIBLE, "DISABLED_SCOPE_INACCESSIBLE"),
+                    Arguments.of(WebhookStatus.DISABLED_ADMINISTRATIVE, "DISABLED_ADMINISTRATIVE")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/WorkspaceCopyInclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/WorkspaceCopyInclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,38 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
+class WorkspaceCopyInclusionTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(WorkspaceCopyInclusion workspaceCopyInclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = workspaceCopyInclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(WorkspaceCopyInclusion.values()).hasSize(11);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(WorkspaceCopyInclusion.ATTACHMENTS, "attachments"),
+                    Arguments.of(WorkspaceCopyInclusion.BRAND, "brand"),
+                    Arguments.of(WorkspaceCopyInclusion.CELLLINKS, "cellLinks"),
+                    Arguments.of(WorkspaceCopyInclusion.DATA, "data"),
+                    Arguments.of(WorkspaceCopyInclusion.DISCUSSIONS, "discussions"),
+                    Arguments.of(WorkspaceCopyInclusion.FILTERS, "filters"),
+                    Arguments.of(WorkspaceCopyInclusion.FORMS, "forms"),
+                    Arguments.of(WorkspaceCopyInclusion.RULERECIPIENTS, "ruleRecipients"),
+                    Arguments.of(WorkspaceCopyInclusion.RULES, "rules"),
+                    Arguments.of(WorkspaceCopyInclusion.SHARES, "shares"),
+                    Arguments.of(WorkspaceCopyInclusion.ALL, "all")
             );
         }
     }

--- a/src/test/java/com/smartsheet/api/models/enums/WorkspaceRemapExclusionTest.java
+++ b/src/test/java/com/smartsheet/api/models/enums/WorkspaceRemapExclusionTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.smartsheet.api.models;
+package com.smartsheet.api.models.enums;
 
-import com.smartsheet.api.models.enums.ObjectInclusion;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,36 +26,30 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ObjectInclusionTest {
-
+class WorkspaceRemapExclusionTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ToStringTests {
         @ParameterizedTest
         @MethodSource("toStringArguments")
-        void toString(ObjectInclusion objectInclusion, String expectedString) {
+        void toString(WorkspaceRemapExclusion workspaceRemapExclusion, String expectedString) {
             // Act
-            String result = objectInclusion.toString();
+            String result = workspaceRemapExclusion.toString();
 
             // Assert
             assertThat(result).isEqualTo(expectedString);
 
             // This will cause the test to fail if we ever add a new value.
             // Please remember to add the new value in the method below
-            assertThat(ObjectInclusion.values()).hasSize(9);
+            assertThat(WorkspaceRemapExclusion.values()).hasSize(4);
         }
 
         private Stream<Arguments> toStringArguments() {
             return Stream.of(
-                    Arguments.of(ObjectInclusion.DISCUSSIONS, "discussions"),
-                    Arguments.of(ObjectInclusion.ATTACHMENTS, "attachments"),
-                    Arguments.of(ObjectInclusion.DATA, "data"),
-                    Arguments.of(ObjectInclusion.COLUMNS, "columns"),
-                    Arguments.of(ObjectInclusion.TEMPLATES, "templates"),
-                    Arguments.of(ObjectInclusion.FORMS, "forms"),
-                    Arguments.of(ObjectInclusion.CELL_LINKS, "cellLinks"),
-                    Arguments.of(ObjectInclusion.FORMAT, "format"),
-                    Arguments.of(ObjectInclusion.SOURCE, "source")
+                    Arguments.of(WorkspaceRemapExclusion.CELLLINKS, "cellLinks"),
+                    Arguments.of(WorkspaceRemapExclusion.REPORTS, "reports"),
+                    Arguments.of(WorkspaceRemapExclusion.SHEETHYPERLINKS, "sheetHyperlinks"),
+                    Arguments.of(WorkspaceRemapExclusion.SIGHTS, "sights")
             );
         }
     }


### PR DESCRIPTION
Gets the code coverage to 100% for the api/models/enums classes. Brings the total code coverage up to 63% from 56%


### Code Coverage with New Tests:
<img width="1088" alt="image" src="https://github.com/smartsheet/smartsheet-java-sdk/assets/24887311/2d4c965c-9f19-4285-a7c1-d9d948d8f867">


### Code Coverage in Mainline:
<img width="1089" alt="image" src="https://github.com/smartsheet/smartsheet-java-sdk/assets/24887311/a2dd5147-8005-4c7a-b7a2-c37d4ba93fec">
