### PR TITLE
Checkstyle fixes and refactor DefaultHttpClient#request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,5 +242,5 @@ checkstyle {
 checkstyleMain {
     // Since our main classes still have some outstanding checkstyle violations, we can allow up to 20 errors so we don't fail on the
     // existing violations, but will fail if we add any new ones. We do not allow _any_ violations in test files.
-    maxErrors = 20
+    maxErrors = 5
 }

--- a/config/checkstyle/checkstyle-custom.xml
+++ b/config/checkstyle/checkstyle-custom.xml
@@ -225,10 +225,10 @@
         <!-- Make sure there is only one occurrence of each string per file -->
 <!--        This check was disabled as it flagged strings in the constructors of Enums.
             Using constants for these literals seemed unnecessary -->
-<!--        <module name="MultipleStringLiterals" >-->
-<!--            <property name="ignoreStringsRegexp" value='^("")|(",\s*)|(".")'/>-->
-<!--            <property name="allowedDuplicates" value="2"/>-->
-<!--        </module>-->
+        <module name="MultipleStringLiterals" >
+            <property name="ignoreStringsRegexp" value='^("")|(",\s*)|(".")'/>
+            <property name="allowedDuplicates" value="2"/>
+        </module>
         <!-- Only one variable declaration per line -->
         <module name="MultipleVariableDeclarations"/>
         <!-- Max number of nested for loops -->
@@ -349,7 +349,7 @@
         </module>
         <!-- Generic parameter names for classes MyClass<T> -->
         <module name="ClassTypeParameterName">
-            <property name="format" value="^[A-Z][A-Za-z]{0,6}$"/>
+            <property name="format" value="^[A-Z]$"/>
         </module>
         <module name="ConstantName">
             <!-- Allow log or logger or CONSTANTS_LIKE_THIS -->

--- a/config/checkstyle/checkstyle-custom.xml
+++ b/config/checkstyle/checkstyle-custom.xml
@@ -223,10 +223,12 @@
             <property name="skipEnhancedForLoopVariable" value="true"/>
         </module>
         <!-- Make sure there is only one occurrence of each string per file -->
-        <module name="MultipleStringLiterals">
-            <property name="ignoreStringsRegexp" value='^("")|(",\s*)|(".")'/>
-            <property name="allowedDuplicates" value="2"/>
-        </module>
+<!--        This check was disabled as it flagged strings in the constructors of Enums.
+            Using constants for these literals seemed unnecessary -->
+<!--        <module name="MultipleStringLiterals" >-->
+<!--            <property name="ignoreStringsRegexp" value='^("")|(",\s*)|(".")'/>-->
+<!--            <property name="allowedDuplicates" value="2"/>-->
+<!--        </module>-->
         <!-- Only one variable declaration per line -->
         <module name="MultipleVariableDeclarations"/>
         <!-- Max number of nested for loops -->
@@ -343,11 +345,11 @@
             <!-- Ignore final variables but don't ignore static, that way constants get ignored -->
             <property name="ignoreFinal" value="false"/>
             <!-- Ban all abbreviations except those enumerated below -->
-            <property name="allowedAbbreviationLength" value="2"/>
+            <property name="allowedAbbreviationLength" value="4"/>
         </module>
         <!-- Generic parameter names for classes MyClass<T> -->
         <module name="ClassTypeParameterName">
-            <property name="format" value="^[A-Za-z]$"/>
+            <property name="format" value="^[A-Z][A-Za-z]{0,6}$"/>
         </module>
         <module name="ConstantName">
             <!-- Allow log or logger or CONSTANTS_LIKE_THIS -->

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -15,4 +15,12 @@
     <suppress files="[\\/]src[\\/]test[\\/].*" checks="FileLength" />
     <!-- Don't check method lengths for tests -->
     <suppress files="[\\/]src[\\/]test[\\/].*" checks="MethodLength" />
+
+<!--    These classes use TRow TColumn and TCell which are confusing to replace with single letter types -->
+    <suppress checks="ClassTypeParameterName" files="src/main/java/com/smartsheet/api/models/AbstractSheet.java"/>
+    <suppress checks="ClassTypeParameterName" files="src/main/java/com/smartsheet/api/models/AbstractRow.java"/>
+
+<!--    These classes are enums with multiple enums using the same string in value -->
+    <suppress checks="MultipleStringLiterals" files="src/main/java/com/smartsheet/api/models/format/Currency.java"/>
+    <suppress checks="MultipleStringLiterals" files="src/main/java/com/smartsheet/api/models/format/FontFamily.java"/>
 </suppressions>

--- a/src/main/java/com/smartsheet/api/internal/http/AndroidHttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/AndroidHttpClient.java
@@ -160,6 +160,9 @@ public class AndroidHttpClient implements HttpClient {
                     case DELETE:
                         builder.delete();
                         break;
+                    default:
+                        // This switch is exhaustive, but the checkstyle doesn't know that
+                        throw new UnsupportedOperationException("Unsupported method: " + smartsheetRequest.getMethod());
                 }
             } catch (IOException e) {
                 throw new HttpClientException(ERROR_OCCURRED, e);

--- a/src/main/java/com/smartsheet/api/internal/http/RequestAndResponseData.java
+++ b/src/main/java/com/smartsheet/api/internal/http/RequestAndResponseData.java
@@ -20,7 +20,6 @@ import com.smartsheet.api.Trace;
 import org.apache.http.Header;
 import org.apache.http.client.methods.HttpRequestBase;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class RequestAndResponseData {
             return headers;
         }
 
-        abstract static class Builder<Type extends HttpPayloadData> {
+        abstract static class Builder<T extends HttpPayloadData> {
             public void withHeaders() {
                 // this is seaprate from addHeader in case headers were requested but none found
                 if (getDataObject().headers == null) {
@@ -69,11 +68,11 @@ public class RequestAndResponseData {
                 return this;
             }
 
-            public abstract Type build();
+            public abstract T build();
 
             public abstract void reset();
 
-            protected abstract Type getDataObject();
+            protected abstract T getDataObject();
         }
     }
 
@@ -281,8 +280,7 @@ public class RequestAndResponseData {
      */
     public static RequestAndResponseData of(HttpRequestBase request, HttpEntitySnapshot requestEntity,
                                             HttpResponse response, HttpEntitySnapshot responseEntity,
-                                            Set<Trace> traces)
-            throws IOException {
+                                            Set<Trace> traces) {
         RequestData.Builder requestBuilder = new RequestData.Builder();
         ResponseData.Builder responseBuilder = new ResponseData.Builder();
 

--- a/src/main/java/com/smartsheet/api/internal/util/QueryUtil.java
+++ b/src/main/java/com/smartsheet/api/internal/util/QueryUtil.java
@@ -44,7 +44,7 @@ public class QueryUtil {
     /**
      * Generate a URL
      */
-    public static String generateUrl(@Nullable String baseUrl, @Nullable Map<String, ? extends Object> parameters) {
+    public static String generateUrl(@Nullable String baseUrl, @Nullable Map<String, ?> parameters) {
         if (baseUrl == null) {
             baseUrl = "";
         }
@@ -57,14 +57,14 @@ public class QueryUtil {
      * @param parameters the map of query string keys and values
      * @return the query string
      */
-    private static String generateQueryString(@Nullable Map<String, ? extends Object> parameters) {
+    private static String generateQueryString(@Nullable Map<String, ?> parameters) {
         if (parameters == null || parameters.isEmpty()) {
             return "";
         }
         StringBuilder result = new StringBuilder();
-        for (Map.Entry<String, ? extends Object> entry : parameters.entrySet()) {
+        for (Map.Entry<String, ?> entry : parameters.entrySet()) {
             // Check to see if the key/value isn't null or empty string
-            if (entry.getKey() != null && (entry.getValue() != null && !entry.getValue().toString().equals(""))) {
+            if (entry.getKey() != null && entry.getValue() != null && !entry.getValue().toString().isEmpty()) {
                 String encodedQueryParam = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8);
                 String encodedQueryValue = URLEncoder.encode(entry.getValue().toString(), StandardCharsets.UTF_8);
                 result

--- a/src/main/java/com/smartsheet/api/models/DateObjectValue.java
+++ b/src/main/java/com/smartsheet/api/models/DateObjectValue.java
@@ -89,12 +89,14 @@ public class DateObjectValue implements ObjectValue {
             switch (objectValueType) {
                 case ABSTRACT_DATETIME:
                     return ABSTRACT_DATETIME_FORMAT;
-
                 case DATETIME:
                     return DATETIME_FORMAT;
-
                 case DATE:
                     return DATE_FORMAT;
+
+                default:
+                    // Throw IllegalArgumentException
+                    break;
             }
         }
 

--- a/src/main/java/com/smartsheet/api/models/format/Format.java
+++ b/src/main/java/com/smartsheet/api/models/format/Format.java
@@ -247,7 +247,7 @@ public class Format {
          */
         public boolean next() {
             pos++;
-            return pos < chars.length || (pos == chars.length && chars[pos - 1] == SEPARATOR);
+            return pos < chars.length || pos == chars.length && chars[pos - 1] == SEPARATOR;
         }
 
         /**


### PR DESCRIPTION
Remaining warnings
```
[ant:checkstyle] [ERROR] /opt/git/sdk/smartsheet-java-sdk/src/main/java/com/smartsheet/api/internal/SheetResourcesImpl.java:81:1: Total number of methods is 47 (max allowed is 40). [MethodCount]
[ant:checkstyle] [ERROR] /opt/git/sdk/smartsheet-java-sdk/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java:338:5: Avoid using finalizer method. [NoFinalizer]
[ant:checkstyle] [ERROR] /opt/git/sdk/smartsheet-java-sdk/src/main/java/com/smartsheet/api/models/AbstractRow.java:26:1: Total number of methods is 60 (max allowed is 40). [MethodCount]
[ant:checkstyle] [ERROR] /opt/git/sdk/smartsheet-java-sdk/src/main/java/com/smartsheet/api/models/AbstractSheet.java:28:1: Total number of methods is 68 (max allowed is 40). [MethodCount]
[ant:checkstyle] [ERROR] /opt/git/sdk/smartsheet-java-sdk/src/main/java/com/smartsheet/api/SheetResources.java:46:1: Total number of methods is 44 (max allowed is 40). [MethodCount]
```