### PR TITLE
Fix deploy Command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish package
-        run: ./gradlew publish -i
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -i
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish package
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -i
+        run: ./gradlew publish -i
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -39,7 +39,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish package
-        run: ./gradlew publish -i
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -i
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -19,3 +19,27 @@ jobs:
         env:
           SMARTSHEET_ACCESS_TOKEN: ${{secrets.SMARTSHEET_ACCESS_TOKEN}}
         run: ./gradlew clean build jacocoTestReport
+
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          server-id: deployment
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v1
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Publish package
+        run: ./gradlew publish -i
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -19,27 +19,3 @@ jobs:
         env:
           SMARTSHEET_ACCESS_TOKEN: ${{secrets.SMARTSHEET_ACCESS_TOKEN}}
         run: ./gradlew clean build jacocoTestReport
-
-  publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          server-id: deployment
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v1
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Publish package
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -i
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     // Allows us to publish our artifact
     id 'maven-publish'
     // Allows us to publish to https://oss.sonatype.org/ and release our artifact
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 
     // ** MAINTENANCE PLUGINS **
     // Allows us to run `./gradlew dependencyUpdates` to check for dependency updates

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 // The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
 // The version. This will be added to the end of the Jar and all other resources that are created during the build.
-version = '3.2.0-SNAPSHOT'
+version = '3.2.0'
 // The Java version:
 sourceCompatibility = '11'
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 // The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
 // The version. This will be added to the end of the Jar and all other resources that are created during the build.
-version = '3.2.0'
+version = '3.2.0-SNAPSHOT'
 // The Java version:
 sourceCompatibility = '11'
 


### PR DESCRIPTION
Updating the Gradle command for deploying to be the correct one. 

I had forgot to do this when I updated to Gradle and release 3.2.0 was unsuccessful because I never merged this change. Now 3.2.0 is out, but we will need this update for future releases.

Without this, changes were getting stuck in Nexus and never getting released to Maven Central