### PR TITLE
Update README.md to fix redoc.ly URL to avoid cert issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Java CI](https://github.com/smartsheet/smartsheet-java-sdk/actions/workflows/test-mainline.yaml/badge.svg)](https://github.com/smartsheet/smartsheet-java-sdk/actions/workflows/test-mainline.yaml) [![Coverage Status](https://coveralls.io/repos/github/smartsheet/smartsheet-java-sdk/badge.svg?branch=mainline)](https://coveralls.io/github/smartsheet/smartsheet-java-sdk?branch=mainline) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.smartsheet/smartsheet-sdk-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.smartsheet/smartsheet-sdk-java/)
 
-This is a Java SDK to simplify connecting to [Smartsheet API](https://www.smartsheet.redoc.ly) in Java applications.
+This is a Java SDK to simplify connecting to [Smartsheet API](https://smartsheet.redoc.ly) in Java applications.
 
 ## System Requirements
 


### PR DESCRIPTION
remove www. prefix from redoc.ly URL as it triggers a cert failure since redoc.ly's cert is only good for `*.redoc.ly` and not `*.*.redoc.ly` and we only need `smartsheet.redoc.ly` to reach the API docs.