### PR TITLE
Bugfix: When fetching discussions, comment attachments were not included if pagination parameters were specified

### DIFF
--- a/src/main/java/com/smartsheet/api/internal/RowDiscussionResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/RowDiscussionResourcesImpl.java
@@ -134,11 +134,10 @@ public class RowDiscussionResourcesImpl extends AbstractResources implements Row
         Map<String, Object> parameters = new HashMap<>();
 
         parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
-        path += QueryUtil.generateUrl(null, parameters);
-
         if (pagination != null) {
-            path += pagination.toQueryString();
+            parameters.putAll(pagination.toHashMap());
         }
+        path += QueryUtil.generateUrl(null, parameters);
 
         return this.listResourcesWithWrapper(path, Discussion.class);
     }

--- a/src/test/java/com/smartsheet/api/HttpTestServer.java
+++ b/src/test/java/com/smartsheet/api/HttpTestServer.java
@@ -40,6 +40,7 @@ public class HttpTestServer {
     private String contentType;
     private byte[] responseBody;
     private int status;
+    private String lastRequestUrl;
 
     public HttpTestServer() {
         this.port = 9090;
@@ -71,7 +72,7 @@ public class HttpTestServer {
                                HttpServletResponse response) throws IOException, ServletException {
 
                 setRequestBody(IOUtils.toString(baseRequest.getInputStream()));
-
+                lastRequestUrl = baseRequest.getOriginalURI();
                 response.setStatus(getStatus());
                 response.setContentType(getContentType());
 
@@ -92,6 +93,10 @@ public class HttpTestServer {
 
     public int getStatus() {
         return this.status;
+    }
+
+    public String getLastRequestUrl() {
+        return this.lastRequestUrl;
     }
 
     public void stop() throws Exception {

--- a/src/test/java/com/smartsheet/api/integrationtest/DiscussionResourcesIT.java
+++ b/src/test/java/com/smartsheet/api/integrationtest/DiscussionResourcesIT.java
@@ -18,12 +18,14 @@ package com.smartsheet.api.integrationtest;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
+import com.smartsheet.api.models.Attachment;
 import com.smartsheet.api.models.Comment;
 import com.smartsheet.api.models.Discussion;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
 import com.smartsheet.api.models.Row;
 import com.smartsheet.api.models.Sheet;
+import com.smartsheet.api.models.enums.AttachmentType;
 import com.smartsheet.api.models.enums.DiscussionInclusion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,7 +78,8 @@ public class DiscussionResourcesIT extends ITResourcesImpl {
 
     public void testCreateDiscussionOnRow() throws SmartsheetException, IOException {
         //add rows
-        row = addRows(sheet.getId());
+        long sheetId = sheet.getId();
+        row = addRows(sheetId);
 
         //create comment to add to discussion
         Comment comment = new Comment.AddCommentBuilder().setText("This is a test comment").build();
@@ -86,8 +90,29 @@ public class DiscussionResourcesIT extends ITResourcesImpl {
                 .rowResources()
                 .discussionResources()
                 .createDiscussion(sheet.getId(), row.getId(), discussion);
-
         assertThat(newDiscussionWithAttachment).isNotNull();
+
+        List<Discussion> fetchedDiscussions = smartsheet
+                .sheetResources()
+                .rowResources()
+                .discussionResources()
+                .listDiscussions(sheetId, row.getId(), null, EnumSet.of(DiscussionInclusion.COMMENTS))
+                .getData();
+        assertThat(fetchedDiscussions.size()).isEqualTo(1);
+        Discussion fetchedDiscussion = fetchedDiscussions.get(0);
+        assertThat(fetchedDiscussion.getComments().size()).isEqualTo(1);
+
+        Comment nestedComment = new Comment.AddCommentBuilder().setText("This is a comment with an attachment").build();
+        Comment newComment = smartsheet
+                .sheetResources()
+                .discussionResources()
+                .commentResources()
+                .addComment(sheetId, newDiscussionWithAttachment.getId(), nestedComment);
+        Attachment attachment = new Attachment();
+        attachment.setUrl("http://www.smartsheet.com/sites/all/themes/blue_sky/logo.png");
+        attachment.setName("logo image");
+        attachment.setAttachmentType(AttachmentType.LINK);
+        smartsheet.sheetResources().commentResources().attachmentResources().attachUrl(sheetId, newComment.getId(), attachment);
     }
 
     public void testCreateDiscussionWithAttachmentOnRow() throws SmartsheetException, IOException {
@@ -127,6 +152,17 @@ public class DiscussionResourcesIT extends ITResourcesImpl {
                 .discussionResources()
                 .listDiscussions(sheet.getId(), row.getId(), parameters, discussionInclusions);
         assertThat(newDiscussion).isNotNull();
+
+        List<Discussion> discussionList = newDiscussion.getData();
+        assertThat(discussionList.size()).isEqualTo(1);
+        Discussion discussion = discussionList.get(0);
+        List<Comment> comments = discussion.getComments();
+        assertThat(comments.size()).isEqualTo(2);
+        Comment comment = comments.get(1);
+        List<Attachment> attachments = comment.getAttachments();
+        assertThat(attachments.size()).isEqualTo(1);
+        Attachment attachment = attachments.get(0);
+        assertThat(attachment.getUrl()).isEqualTo("http://www.smartsheet.com/sites/all/themes/blue_sky/logo.png");
     }
 
     public void testGetAllDiscussions() throws SmartsheetException {

--- a/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowDiscussionResourcesImplTest.java
@@ -92,5 +92,8 @@ class RowDiscussionResourcesImplTest extends ResourcesImplBase {
         );
         assertThat(newDiscussion.getData().get(0).getTitle()).isEqualTo("Lincoln");
         assertThat(newDiscussion.getData().get(0).getId()).isEqualTo(3138415114905476L);
+        assertThat(newDiscussion.getData().get(0).getComments().get(0).getAttachments().get(0).getName()).isEqualTo("test.html");
+        assertThat(server.getLastRequestUrl())
+                .isEqualTo("/1.1/sheets/1234/rows/5678/discussions?include=comments&pageSize=1&includeAll=false&page=1");
     }
 }


### PR DESCRIPTION
### Summary

When fetching discussions for a row, there is an option to fetch the comments associated with each discussion and the attachments for each comment. There is a bug in the SDK that is preventing the attachments for comments from being returned if the user specifies paging parameters. 

```
PaginationParameters parameters = new PaginationParameters.PaginationParametersBuilder().setIncludeAll(true).build();
EnumSet<DiscussionInclusion> discussionInclusions = EnumSet.of(DiscussionInclusion.COMMENTS, DiscussionInclusion.ATTACHMENTS);
PagedResult<Discussion> discussion = smartsheet
                .sheetResources()
                .rowResources()
                .discussionResources()
                .listDiscussions(sheet.getId(), row.getId(), parameters, discussionInclusions);
List<Attachments> attachments = newDiscussion.getData().get(0).getComments().get(0).getAttachments(); 
attachments <---- attachments are null
```

This is happening because, when building the URL path to retrieve the list of discussions, if we specify both include parameters and pagination parameters, the resulting path has two "?" characters:

```
sheets/8124026088056708/rows/3056197762541444/discussions?include=comments,attachments?includeAll=true
```

When this happens, the Smartsheet API will ignore the `include` parameter and only take into account the `includeAll` parameter.

In this PR we are making sure that when both pagination parameters and include parameters are specified, the resulting path  is built correctly:

```
sheets/8124026088056708/rows/3056197762541444/discussions?include=comments,attachments&includeAll=true
```
