### PR TITLE
fix(security): update okhttp3 to get ridof vulnerabilities CVE-2023-3635

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     jUnitJupiterVersion = '5.5.1'
     mockitoCoreVersion = '5.12.0'
     mockitoJUnitJupiterVersion = '5.12.0'
-    okHttpVersion = '4.0.0'
+    okHttpVersion = '4.12.0'
     resilience4jVersion = "1.7.1"   // last version compatible with pre-17 JDKs
     slf4jSimpleVersion = '1.7.25'
     slf4jVersion = '1.7.25'


### PR DESCRIPTION
CVE-2021-0341 (okhttp):

Description: This vulnerability in OkHostnameVerifier.java could allow a certificate for the wrong domain to be accepted due to improperly used cryptography. This can lead to remote information disclosure without requiring additional execution privileges1.
Affected Versions: All versions of okhttp v3.x and v4.x are affected.
CVE-2023-3635 (okio):

Description: The GzipSource class does not handle exceptions properly when parsing a malformed gzip buffer. This can lead to a denial of service (DoS) when handling a crafted GZIP archive2.

**Proposed Solution**
Both issues are solved by updating okhttp to 4.12.0