### PR TITLE
Mark the modifiedDate field as deprecated in the Comment model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [x.x.x] - unreleased
 ### Changed
 - Update the copyright year to 2025
+- Marked the modifiedDate field as deprecated in the Comment model.
 
 
 ## [3.2.2] - 2024-12-10

--- a/src/main/java/com/smartsheet/api/models/Comment.java
+++ b/src/main/java/com/smartsheet/api/models/Comment.java
@@ -36,7 +36,10 @@ public class Comment extends IdentifiableModel<Long> {
 
     /**
      * Represents the date the comment was modified.
+     *
+     * @deprecated use modifiedAt instead.
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     private Date modifiedDate;
 
     /**
@@ -111,7 +114,9 @@ public class Comment extends IdentifiableModel<Long> {
      * Gets the date the comment was last modified.
      *
      * @return the modified date
+     * @deprecated use getModifiedAt instead.
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     public Date getModifiedDate() {
         return modifiedDate;
     }
@@ -120,7 +125,9 @@ public class Comment extends IdentifiableModel<Long> {
      * Sets the date the comment was last modified.
      *
      * @param modifiedDate the new modified date
+     * @deprecated use setModifiedAt instead.
      */
+    @Deprecated(since = "3.2.3", forRemoval = true)
     public Comment setModifiedDate(Date modifiedDate) {
         this.modifiedDate = modifiedDate;
         return this;


### PR DESCRIPTION
This pull request marks the `modifiedDate` field as deprecated in the Comment model.

This field has been deprecated since the version two release of the public API.

