### PR TITLE
Prevent HTTP connection leak on network exceptions

### DIFF
--- a/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
@@ -288,6 +288,7 @@ public class DefaultHttpClient implements HttpClient {
                 this.releaseConnection();
 
             } catch (ClientProtocolException e) {
+                this.releaseConnection();
                 logger.warn("ClientProtocolException " + e.getMessage());
                 logger.warn(LOG_ARG, RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
                         responseEntityCopy, REQUEST_RESPONSE_SUMMARY));
@@ -305,6 +306,7 @@ public class DefaultHttpClient implements HttpClient {
                 }
                 throw new HttpClientException(ERROR_OCCURRED, e);
             } catch (NoHttpResponseException e) {
+                this.releaseConnection();
                 logger.warn("NoHttpResponseException {}", e.getMessage());
                 logger.warn(LOG_ARG, RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
                         responseEntityCopy, REQUEST_RESPONSE_SUMMARY));
@@ -322,6 +324,7 @@ public class DefaultHttpClient implements HttpClient {
                 }
                 throw new HttpClientException(ERROR_OCCURRED, e);
             } catch (IOException e) {
+                this.releaseConnection();
                 logger.warn(LOG_ARG, RequestAndResponseData.of(apacheHttpRequest, requestEntityCopy, smartsheetResponse,
                         responseEntityCopy, REQUEST_RESPONSE_SUMMARY));
                 throw new HttpClientException(ERROR_OCCURRED, e);


### PR DESCRIPTION
## Summary
Fix: Prevent HTTP connection leak on network exceptions

## Problem:
The SDK experiences cascading SocketTimeoutException errors under load. The frequency of these timeouts increases the longer the application is running. This behavior points to a resource leak in the underlying Apache HttpClient's connection pool.

The root cause was identified in the DefaultHttpClient.request() method. Several catch blocks for network-related exceptions (e.g., IOException, ClientProtocolException, NoHttpResponseException) would log the error and re-throw it without releasing the underlying HTTP connection. This meant that any time a request failed with a socket timeout or other network issue, a connection was permanently leased from the pool and never returned. Over time, this exhausts the connection pool, causing all subsequent requests to hang until they also time out.

## Solution:
This simply releases the connections where necessary to ensure the pool doesn't get exhausted.

## Checklist

<!-- Checklist must be completed before maintainer can review -->

* [x] Read the **[contribution guide](https://github.com/smartsheet/smartsheet-java-sdk/blob/mainline/ADVANCED.md)**
* [x] Successfully build your changes locally - Run `./gradlew clean build`
* [x] Include a title that clearly describes your changes and references relevant issues / backlog items
* [x] Include a summary of your changes
* [x] Include tests for your changes where possible
