### PR TITLE
Fix javadoc publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,14 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@v2.3.0
+        uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: gh-pages
           java-version: 11
           target-folder: apidocs # url will be https://<username>.github.io/<repo>/javadoc
           project: gradle
+          custom-command: ./gradlew javadoc
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -16,7 +16,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: gh-pages

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -5,26 +5,6 @@ on:
       branches: [ mainline ]
 
 jobs:
-  publish-docs:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@v2.3.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          javadoc-branch: gh-pages
-          java-version: 11
-          target-folder: apidocs # url will be https://<username>.github.io/<repo>/javadoc
-          project: gradle
-          custom-command: ./gradlew javadoc
-
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -5,6 +5,26 @@ on:
       branches: [ mainline ]
 
 jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Deploy JavaDoc 🚀
+        uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          javadoc-branch: gh-pages
+          java-version: 11
+          target-folder: apidocs # url will be https://<username>.github.io/<repo>/javadoc
+          project: gradle
+          custom-command: ./gradlew javadoc
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

Our Javadoc job is defaulting to the latest Gradle version which does not support Java 11 anymore. This is causing the javadoc publish to fail because it expects at least Java 17.

This fix tells that publishing to use Gradle Wrapper so we pick up our correct version of Gradle rather than always using the latest. Our version of Gradle works with Java 11

... might be time to start thinking about Java 17

## Checklist

<!-- Checklist must be completed before maintainer can review -->

* [x] Read the **[contribution guide](https://github.com/smartsheet/smartsheet-java-sdk/blob/mainline/ADVANCED.md)**
* [x] Successfully build your changes locally - Run `./gradlew clean build`
* [x] Include a title that clearly describes your changes and references relevant issues / backlog items
* [x] Include a summary of your changes
* [x] Include tests for your changes where possible
