### PR TITLE
Add objectIdStr field to Event model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - unreleased
 
+## [3.11.0] - 2026-04-22
+### Added
+- Added `objectIdStr` field to Event model to support alphanumeric object identifiers in v2.0 events endpoint
+- Field is optional and maintains full backward compatibility with existing implementations
+
 ## [3.10.1] - 2026-03-31
 ### Fixed
 - Fixed WORKSPACES endpoint constant in SheetResourcesImpl to use lowercase "workspaces" instead of uppercase "WORKSPACES", resolving 404 errors when creating sheets in workspaces

--- a/src/main/java/com/smartsheet/api/models/Event.java
+++ b/src/main/java/com/smartsheet/api/models/Event.java
@@ -57,6 +57,11 @@ public class Event {
     private Object objectId;
 
     /**
+     * Alphanumeric object identifier for v2.0+ support
+     */
+    private String objectIdStr;
+
+    /**
      * The Smartsheet resource impacted by the event
      */
     private EventObjectType objectType;
@@ -195,6 +200,25 @@ public class Event {
      */
     public Event setObjectId(Object objectId) {
         this.objectId = objectId;
+        return this;
+    }
+
+    /**
+     * Gets the alphanumeric object identifier
+     *
+     * @return the alphanumeric object identifier
+     */
+    public String getObjectIdStr() {
+        return objectIdStr;
+    }
+
+    /**
+     * Sets the alphanumeric object identifier
+     *
+     * @param objectIdStr the alphanumeric object identifier
+     */
+    public Event setObjectIdStr(String objectIdStr) {
+        this.objectIdStr = objectIdStr;
         return this;
     }
 


### PR DESCRIPTION
## Summary
Adds the `objectIdStr` field with getter/setter to the Event class to support alphanumeric object identifiers.

## Changes
- ✅ Added `private String objectIdStr;` field
- ✅ Added `getObjectIdStr()` and `setObjectIdStr()` methods
- ✅ Added Javadoc comments
- ✅ Updated CHANGELOG.md
- ✅ Follows builder pattern (setter returns `this`)