### PR TITLE
docs(events): document and deprecate `objectId` in favor of `objectIdStr` (AUD-907)

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -534,6 +534,22 @@ Many events have additional information available as part of the event. That inf
 HashMap stored in the `additionalDetails` property. Information about the additional details provided can be found
 [here.](https://smartsheet.redoc.ly/tag/eventsDescription)
 
+Each event identifies the object it affected. Use the `getObjectIdStr()` accessor, which returns the
+object identifier as a `String` and supports both numeric and non-numeric identifiers. The older
+`getObjectId()` accessor is deprecated and kept only for backward compatibility: when the identifier
+is numeric it returns the number, and when the identifier is non-numeric it returns `-1` while the
+real value is available from `getObjectIdStr()`. New code should read `getObjectIdStr()`.
+
+```java
+for (Event event : events) {
+    // Preferred: works for all identifier types
+    System.out.println(event.getObjectIdStr());
+
+    // Deprecated: numeric only; returns -1 for non-numeric identifiers
+    // System.out.println(event.getObjectId());
+}
+```
+
 ```java
 public class Sample {
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+### Deprecated
+
+- Deprecated `Event.getObjectId()`; use `Event.getObjectIdStr()` instead. `objectId` is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal.
+
 ## [4.1.0] - 2026-06-26
 
 ### Fixed

--- a/src/main/java/com/smartsheet/api/models/Event.java
+++ b/src/main/java/com/smartsheet/api/models/Event.java
@@ -185,10 +185,14 @@ public class Event {
     }
 
     /**
-     * Get the object ID of the object associated with the event
+     * Get the object ID of the object associated with the event.
      *
+     * @deprecated Use {@link #getObjectIdStr()} instead. {@code objectId} is numeric only and
+     *     returns -1 for non-numeric identifiers. It is not scheduled for removal, but new code
+     *     should read {@code objectIdStr}, which represents all identifier values.
      * @return the object ID
      */
+    @Deprecated
     public Object getObjectId() {
         return objectId;
     }

--- a/src/main/java/com/smartsheet/api/models/Event.java
+++ b/src/main/java/com/smartsheet/api/models/Event.java
@@ -187,10 +187,10 @@ public class Event {
     /**
      * Get the object ID of the object associated with the event.
      *
+     * @return the object ID
      * @deprecated Use {@link #getObjectIdStr()} instead. {@code objectId} is numeric only and
      *     returns -1 for non-numeric identifiers. It is not scheduled for removal, but new code
      *     should read {@code objectIdStr}, which represents all identifier values.
-     * @return the object ID
      */
     @Deprecated
     public Object getObjectId() {

--- a/src/test/java/com/smartsheet/api/models/EventTest.java
+++ b/src/test/java/com/smartsheet/api/models/EventTest.java
@@ -64,7 +64,6 @@ class EventTest {
         }
 
         @Test
-        @SuppressWarnings("deprecation") // exercises the deprecated getObjectId() accessor on purpose
         void deserialize_doesNotAffectOtherFields() throws Exception {
             String json = "{\"eventId\":\"evt-42\",\"objectId\":999,\"objectIdStr\":\"xyz-789\",\"objectType\":\"SHEET\"}";
 

--- a/src/test/java/com/smartsheet/api/models/EventTest.java
+++ b/src/test/java/com/smartsheet/api/models/EventTest.java
@@ -64,6 +64,7 @@ class EventTest {
         }
 
         @Test
+        @SuppressWarnings("deprecation") // exercises the deprecated getObjectId() accessor on purpose
         void deserialize_doesNotAffectOtherFields() throws Exception {
             String json = "{\"eventId\":\"evt-42\",\"objectId\":999,\"objectIdStr\":\"xyz-789\",\"objectType\":\"SHEET\"}";
 


### PR DESCRIPTION
## Summary
 
Documents the `objectIdStr` field on the `Event` model and marks the older numeric `getObjectId()` accessor as deprecated. The `objectIdStr` field itself was added to the SDK in #171; this PR adds the user-facing documentation and the deprecation marker.
 
`getObjectIdStr()` returns the affected object's identifier as a `String` and supports both numeric and non-numeric identifiers. The existing numeric `getObjectId()` accessor is deprecated (kept for backward compatibility) — it returns `-1` when the identifier is non-numeric, in which case the real value is only available from `getObjectIdStr()`. New code should read `getObjectIdStr()`.
 
## Changes
 
- `ADVANCED.md` — add an explanatory paragraph plus a before/after code sample to the Event Reporting section showing `event.getObjectIdStr()` (preferred) vs. `event.getObjectId()` (deprecated).
- `Event.java` — add `@Deprecated` annotation and `@deprecated` Javadoc to `getObjectId()` pointing to `getObjectIdStr()`.
- `EventTest.java` — add `@SuppressWarnings("deprecation")` to the one test that intentionally exercises `getObjectId()`.
- `CHANGELOG.md` — add a `Deprecated` entry under Unreleased.
## Notes for reviewers
 
- This is a **soft** deprecation. The Javadoc states that `objectId` is *not* scheduled for removal — matching the API changelog (Jun-08-2026). Please flag if you'd prefer stronger or weaker language.
- No build impact: the build does not fail on warnings, and the only internal reference (a deserialization test) is annotated with `@SuppressWarnings("deprecation")`.
- Part of AUD-907. Parallel PRs apply the equivalent documentation + deprecation to the Python, JavaScript, and C# SDKs, and a cross-language migration guide is going into `api-docs`.
## Related
 
- Jira: AUD-907
- Code PR: #171 (added the `objectIdStr` field)
 