### PR TITLE
Prepare for release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.1.0] - 2026-06-26
+
 ### Fixed
 
 - Deprecation related corrections

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 // The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
 // The version. This will be added to the end of the Jar and all other resources that are created during the build.
-version = '4.0.0'
+version = '4.1.0'
 // The Java version:
 sourceCompatibility = '11'
 


### PR DESCRIPTION
## Summary

Release prep for v4.1.0 (minor — all changes additive). Bumps `version` to 4.1.0 in `build.gradle` and stamps the CHANGELOG `Unreleased` section with `## [4.1.0] - 2026-06-26`.

Released content accumulated on `mainline` since v4.0.0:
- **Added:** GET path endpoints (`getSheetPath`, `getReportPath`, `getSightPath`, `getFolderPath`) with `getLeaf<Asset>()` / `getLeaf<Asset>Path()` helpers; hardcoded `paginationType=token` for `listWorkspaces`.
- **Fixed:** Deprecation-related corrections.

## Test plan
- [ ] `./gradlew clean build` passes on the release branch