### PR TITLE
Add release docs and skills

### DIFF
--- a/.claude/skills/releasing-smartsheet-java-sdk/SKILL.md
+++ b/.claude/skills/releasing-smartsheet-java-sdk/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: releasing-smartsheet-java-sdk
+description: Use when cutting a new release of the Smartsheet Java SDK — version bump, changelog, tag, and GitHub Release
+---
+
+# Release
+
+## Overview
+
+Skill for releasing a new version of the Smartsheet Java SDK.
+
+**Full procedure:** Read `RELEASE.md` in the repository root before taking any action. It is the single source of truth for every step, decision rule, and checklist item.
+
+## When to Use
+
+Use when:
+- User asks to cut a release or bump the version
+- It's time to ship accumulated changes from `mainline`
+- A hotfix needs to be published urgently
+
+Do NOT use for:
+- Adding features or fixing bugs (those are separate PRs merged first)
+- Updating CI or tooling without a version change
+
+## Workflow Summary
+
+```
+mainline (green) → decide version → "Prepare for release" PR → merge → GitHub Release (creates tag) → sign + publish to Maven Central (auto)
+```
+
+Full details for every step are in `RELEASE.md`.
+
+## Confirmation Gates
+
+**Before committing or pushing anything:** confirm the target version and branch name with the user.
+
+**Before instructing the user to click "Publish release":** confirm they are ready — publishing is the point of no return that triggers Maven Central publication and cannot be undone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AI Agent Workflows
+
+This repository uses workflow-specific agents to handle different phases of SDK development. Each agent is backed by a detailed skill file that defines the workflow, and this document provides the project-specific context agents need to work effectively in this codebase.
+
+## Available Agents
+
+- **Implementation Agent** - Adding or modifying API endpoints
+- **Review Agent** - Reviewing endpoint implementations before merge
+- **Release Agent** - Cutting a new SDK release (version bump, changelog, tag, GitHub Release)
+
+---
+
+## Implementation Agent
+
+### Purpose
+
+Adding or modifying Smartsheet API endpoints in the Java SDK.
+
+### Skill Reference
+
+**Skill file:** `.claude/skills/implement-api-endpoint/SKILL.md`
+
+### When to Use
+
+Use the Implementation Agent when:
+- User requests endpoint implementation
+- Adding a new API endpoint to the SDK
+- Modifying existing endpoint behavior
+
+Do NOT use for:
+- Bug fixes in existing endpoints (unless spec changed)
+- Refactoring without behavior changes
+- Documentation-only changes
+
+---
+
+## Review Agent
+
+### Purpose
+
+Systematic code review for API endpoint implementations before merge.
+
+### Skill Reference
+
+**Skill file:** `.claude/skills/review-api-endpoint/SKILL.md`
+
+### When to Use
+
+Use the Review Agent when:
+- Reviewing a pull request with endpoint changes
+- Verifying endpoint implementation before merge
+- Quality check before release
+
+Do NOT use for:
+- Non-endpoint code reviews
+- Documentation-only changes
+
+---
+
+## Release Agent
+
+### Purpose
+
+Cutting a new SDK release: determining the correct semver bump, updating the changelog, bumping the version, creating the release PR, tagging, and publishing via GitHub Release.
+
+### Skill Reference
+
+**Skill file:** `.claude/skills/releasing-smartsheet-java-sdk/SKILL.md`
+
+**Full procedure:** `RELEASE.md` in the repository root — single source of truth for every step, decision rule, and checklist item.
+
+### When to Use
+
+Use the Release Agent when:
+- User asks to cut a release or publish a new version
+- Accumulated changes on `mainline` need to be shipped
+- A hotfix needs to be released urgently
+
+Do NOT use for:
+- Implementing features or fixing bugs (merge those first)
+- CI or tooling changes without a version bump
+
+---
+
+## Project-Specific Context
+
+This section provides shared context that applies to all agents working in this repository.
+
+### Repository Overview
+
+**Name:** Smartsheet Java SDK
+
+**Purpose:** Client library for the Smartsheet REST API, enabling Java applications to interact with Smartsheet programmatically.
+
+**Build tool:** Gradle (`build.gradle`)
+
+**Java version:** 11
+
+### Key Documentation Files
+
+| File | Purpose | When to Read |
+|------|---------|--------------|
+| `RELEASE.md` | Release procedure, version bump, changelog, tagging | Cutting a new SDK release |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,10 @@
 # AI Agent Workflows
 
-This repository uses workflow-specific agents to handle different phases of SDK development. Each agent is backed by a detailed skill file that defines the workflow, and this document provides the project-specific context agents need to work effectively in this codebase.
+This repository uses workflow-specific agents to handle different phases of SDK development.
 
 ## Available Agents
 
-- **Implementation Agent** - Adding or modifying API endpoints
-- **Review Agent** - Reviewing endpoint implementations before merge
 - **Release Agent** - Cutting a new SDK release (version bump, changelog, tag, GitHub Release)
-
----
-
-## Implementation Agent
-
-### Purpose
-
-Adding or modifying Smartsheet API endpoints in the Java SDK.
-
-### Skill Reference
-
-**Skill file:** `.claude/skills/implement-api-endpoint/SKILL.md`
-
-### When to Use
-
-Use the Implementation Agent when:
-- User requests endpoint implementation
-- Adding a new API endpoint to the SDK
-- Modifying existing endpoint behavior
-
-Do NOT use for:
-- Bug fixes in existing endpoints (unless spec changed)
-- Refactoring without behavior changes
-- Documentation-only changes
-
----
-
-## Review Agent
-
-### Purpose
-
-Systematic code review for API endpoint implementations before merge.
-
-### Skill Reference
-
-**Skill file:** `.claude/skills/review-api-endpoint/SKILL.md`
-
-### When to Use
-
-Use the Review Agent when:
-- Reviewing a pull request with endpoint changes
-- Verifying endpoint implementation before merge
-- Quality check before release
-
-Do NOT use for:
-- Non-endpoint code reviews
-- Documentation-only changes
 
 ---
 
@@ -61,7 +12,7 @@ Do NOT use for:
 
 ### Purpose
 
-Cutting a new SDK release: determining the correct semver bump, updating the changelog, bumping the version, creating the release PR, tagging, and publishing via GitHub Release.
+Cutting a new SDK release: determining the correct semver bump, updating the changelog, bumping the version in `build.gradle`, creating the release PR, tagging, and publishing via GitHub Release.
 
 ### Skill Reference
 
@@ -79,25 +30,3 @@ Use the Release Agent when:
 Do NOT use for:
 - Implementing features or fixing bugs (merge those first)
 - CI or tooling changes without a version bump
-
----
-
-## Project-Specific Context
-
-This section provides shared context that applies to all agents working in this repository.
-
-### Repository Overview
-
-**Name:** Smartsheet Java SDK
-
-**Purpose:** Client library for the Smartsheet REST API, enabling Java applications to interact with Smartsheet programmatically.
-
-**Build tool:** Gradle (`build.gradle`)
-
-**Java version:** 11
-
-### Key Documentation Files
-
-| File | Purpose | When to Read |
-|------|---------|--------------|
-| `RELEASE.md` | Release procedure, version bump, changelog, tagging | Cutting a new SDK release |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Configuration
+
+For workflow-specific agent instructions, see [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ Add the SDK as a dependency in your project.
 </dependency>
 ```
 
-The current artifact version reference can be found [here](https://oss.sonatype.org/#nexus-search;quick~smartsheet)
+The current artifact version reference can be found [here](https://central.sonatype.com/artifact/com.smartsheet/smartsheet-sdk-java)
 
 ### Install By Downloading the Jar File
-<!--* [The SDK packaged in a jar with Dependencies](https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=com.smartsheet&a=smartsheet-sdk-java&v=LATEST) built in.-->
-[SDK packaged as a jar](https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=com.smartsheet&a=smartsheet-sdk-java&v=LATEST). This jar requires that all of the following dependencies are manually added to the path:
+[SDK jar files on Maven Central](https://central.sonatype.com/artifact/com.smartsheet/smartsheet-sdk-java). Navigate to the desired version and download the jar. This jar requires that all of the following dependencies are manually added to the path:
 
 ```
     Apache HttpComponents 4.5
@@ -109,7 +108,7 @@ For details about logging, testing, how to use a passthrough option, and how to 
 
 The full Smartsheet API documentation is here: <https://developers.smartsheet.com/api/smartsheet>
 
-The generated SDK javadoc is here: [https://smartsheet.github.io/smartsheet-java-sdk/apidocs/](https://smartsheet.github.io/smartsheet-java-sdk/apidocs/) (Download as a jar file [here](http://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=com.smartsheet&a=smartsheet-sdk-java&v=LATEST&c=javadoc).)
+The generated SDK javadoc is here: [https://smartsheet.github.io/smartsheet-java-sdk/apidocs/](https://smartsheet.github.io/smartsheet-java-sdk/apidocs/)
 
 ## Contributing
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,158 @@
+# Release Procedure
+
+This document is the single source of truth for releasing the Smartsheet Java SDK. Publishing to Maven Central is automated via GitHub Actions, but the version bump and changelog update are done by hand.
+
+## Overview
+
+Releases follow [Semantic Versioning](https://semver.org/) and [Keep a Changelog](https://keepachangelog.com/) conventions. Every release consists of:
+
+1. A "Prepare for release" PR that bumps the version and closes out the changelog.
+2. A merged commit on `mainline` published as a GitHub Release (which also creates the tag).
+3. Automated signing and publishing to Maven Central triggered by the GitHub Release event.
+
+## Prerequisites
+
+- Write access to the `smartsheet/smartsheet-java-sdk` repository.
+- Maven Central credentials are not needed locally — publishing is done via GitHub Actions secrets (GPG signing + Sonatype credentials).
+
+## Step-by-Step Process
+
+### 1. Decide the version bump
+
+Review the `## [x.x.x] - Unreleased` section in `CHANGELOG.md` and apply semver rules:
+
+| Change type | Bump |
+| --- | --- |
+| New endpoints, non-breaking additions | `minor` |
+| Bug fixes, dependency updates | `patch` |
+| Breaking API changes, removed types/methods | `major` |
+
+### 2. Create a "Prepare for release" pull request
+
+Open a branch from `mainline` (e.g., `release/v4.2.0`) and make the following changes:
+
+#### a. Update `CHANGELOG.md`
+
+Feature PRs accumulate entries under `## [x.x.x] - Unreleased`. For the release, insert the new versioned header between that placeholder and its content:
+
+```diff
+ ## [x.x.x] - Unreleased
+
++## [4.2.0] - 2026-07-15
++
+ ### Added
+```
+
+The `## [x.x.x] - Unreleased` placeholder header is never removed — it stays at the top of the file permanently so future PRs have somewhere to add entries.
+
+#### b. Update `build.gradle`
+
+```diff
+-version = '4.1.0'
++version = '4.2.0'
+```
+
+#### c. PR title convention
+
+```
+Prepare for release vX.X.X
+```
+
+Example: `Prepare for release v4.2.0`
+
+### 3. Merge the PR
+
+CI must pass before merging. The `test-pr.yaml` workflow runs:
+
+- Unit tests and Jacoco coverage
+- Mock API SDK tests
+
+### 4. Create and publish the GitHub Release
+
+1. Go to **Releases → Draft a new release** in the GitHub UI.
+2. In the **Choose a tag** field, type the new version (e.g. `v4.2.0`) and select **Create new tag on publish**.
+3. Set the title to `v4.2.0`.
+4. Set the description to the changelog entries for this version (copy from `CHANGELOG.md`).
+5. Click **Publish release**.
+
+The tag is created automatically when the release is published — no separate `git tag` step needed.
+
+Publishing the release (not just saving as a draft) triggers `release.yml`, which runs two jobs in parallel:
+
+- **publish-docs**: Builds Javadoc and deploys it to the `gh-pages` branch.
+- **publish**: Signs artifacts with GPG and deploys to Maven Central via JReleaser + Sonatype.
+
+### 5. Verify the publish workflow
+
+Go to [Workflow runs](https://github.com/smartsheet/smartsheet-java-sdk/actions) and confirm both the `publish-docs` and `publish` jobs succeeded.
+
+### 6. Verify on Sonatype
+
+Check that the new version appears in the Sonatype Nexus repository:
+
+```
+https://oss.sonatype.org/#nexus-search;quick~smartsheet-java-sdk
+```
+
+Look under the **release repository** → `com/smartsheet/smartsheet-java-sdk`. Credentials are stored in the team's Smartsheet sheet (see your team lead).
+
+### 7. Verify on Maven Central
+
+Maven Central syncs from Sonatype approximately once per day. After ~24 hours, verify:
+
+```
+https://central.sonatype.com/artifact/com.smartsheet/smartsheet-java-sdk
+```
+
+or check the standard Maven Central search at `https://search.maven.org`.
+
+## Files Changed in Every Release
+
+| File | What changes |
+| --- | --- |
+| `CHANGELOG.md` | New versioned header inserted below the permanent `Unreleased` placeholder |
+| `build.gradle` | `version` field bumped |
+
+## Automation
+
+Publishing is fully automated once the GitHub Release is published:
+
+```
+GitHub Release (published) → release.yml → GPG sign → JReleaser → Sonatype → Maven Central (~1 day)
+```
+
+The workflow uses repository secrets for GPG signing and Sonatype credentials — no local setup needed.
+
+## Troubleshooting
+
+**CI fails on the PR**
+
+Check the `test-pr.yaml` run for failing unit tests or mock API tests.
+
+**Publish workflow fails after the release is published**
+
+The tag and GitHub Release already exist — do not delete them. Instead:
+
+1. Investigate the failure in the Actions log (common causes: GPG key expiry, Sonatype credential rotation).
+2. Re-trigger via **Actions → Release Package → Re-run jobs** after fixing the root cause.
+3. If the root cause requires a code fix, cut a patch release instead.
+
+## Rollback
+
+Maven Central does not support un-publishing releases. If a bad release ships:
+
+1. Publish a patch release immediately with the fix.
+2. If the artifact hasn't synced to Maven Central yet, contact Sonatype support to block promotion.
+
+## Checklist
+
+- [ ] Determined correct semver bump
+- [ ] `CHANGELOG.md` versioned header inserted below the permanent `Unreleased` placeholder
+- [ ] `build.gradle` version bumped
+- [ ] PR title: `Prepare for release vX.X.X`
+- [ ] CI passes on the PR
+- [ ] PR merged to `mainline`
+- [ ] GitHub Release created: tag `vX.X.X` set to **Create new tag on publish**, description set to changelog entries, **published** (not draft)
+- [ ] `publish` and `publish-docs` workflow jobs verified as succeeded
+- [ ] Version confirmed in Sonatype Nexus
+- [ ] Version confirmed in Maven Central (~1 day later)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,17 +86,7 @@ Publishing the release (not just saving as a draft) triggers `release.yml`, whic
 
 Go to [Workflow runs](https://github.com/smartsheet/smartsheet-java-sdk/actions) and confirm both the `publish-docs` and `publish` jobs succeeded.
 
-### 6. Verify on Sonatype
-
-Check that the new version appears in the Sonatype Nexus repository:
-
-```
-https://oss.sonatype.org/#nexus-search;quick~smartsheet-java-sdk
-```
-
-Look under the **release repository** → `com/smartsheet/smartsheet-java-sdk`. Credentials are stored in the team's Smartsheet sheet (see your team lead).
-
-### 7. Verify on Maven Central
+### 6. Verify on Maven Central
 
 Maven Central syncs from Sonatype approximately once per day. After ~24 hours, verify:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -91,7 +91,7 @@ Go to [Workflow runs](https://github.com/smartsheet/smartsheet-java-sdk/actions)
 Maven Central syncs from Sonatype approximately once per day. After ~24 hours, verify:
 
 ```
-https://central.sonatype.com/artifact/com.smartsheet/smartsheet-java-sdk
+https://central.sonatype.com/artifact/com.smartsheet/smartsheet-sdk-java
 ```
 
 or check the standard Maven Central search at `https://search.maven.org`.


### PR DESCRIPTION
# Pull Request

## Summary

Add release documentation and AI agent workflow skills for the Smartsheet Java SDK. This introduces:

- **`RELEASE.md`** — Step-by-step release procedure covering version bumps, changelog updates, tagging, and GitHub Release publishing.
- **`AGENTS.md`** — Defines available AI agent workflows (Implementation, Review, Release) with their purposes, skill references, and shared project context.
- **`CLAUDE.md`** — Root-level Claude Code configuration pointing to `AGENTS.md`.
- **Release skill** (`.claude/skills/releasing-smartsheet-java-sdk/SKILL.md`) — Detailed skill file backing the Release Agent workflow.

## Checklist

* [x] Read the **[contribution guide](https://github.com/smartsheet/smartsheet-java-sdk/blob/mainline/ADVANCED.md)**
* [x] Successfully build your changes locally - Run `./gradlew clean build`
* [x] Include a title that clearly describes your changes and references relevant issues / backlog items
* [x] Include a summary of your changes
* [ ] Include tests for your changes where possible — *N/A, documentation-only changes*