### PR TITLE
Prepare for release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.2.0] - 2026-07-09
+
 ### Added
 - Support for GET /2.0/reports/{reportId}/definition (`ReportResources.getReportDefinition`)
 - Support for GET /2.0/reports/{reportId}/columns (`ReportResources.listReportColumns`)

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 // The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
 // The version. This will be added to the end of the Jar and all other resources that are created during the build.
-version = '4.1.0'
+version = '4.2.0'
 // The Java version:
 sourceCompatibility = '11'
 


### PR DESCRIPTION
Release prep for v4.2.0 (minor — all changes additive). Bumps version to 4.2.0 in build.gradle and stamps the CHANGELOG Unreleased section with ## [4.2.0] - 2026-07-09.

Released content accumulated on mainline since v4.1.0:

Added:
- Support for GET /2.0/reports/{reportId}/definition (`ReportResources.getReportDefinition`)
- Support for GET /2.0/reports/{reportId}/columns (`ReportResources.listReportColumns`)
- Support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} (`ReportResources.getReportColumn`)
- Support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} (`ReportResources.updateReportColumn`)
- Support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} (`ReportResources.deleteReportColumn`)
- Support for GET /2.0/reports/{reportId}/scope (`ReportResources.listReportScope`)

Deprecated:
- Deprecated `Event.getObjectId()`; use `Event.getObjectIdStr()` instead. `objectId` is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal.