### PR TITLE
Prepare for release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.3.0] - 2026-07-20
+
 ### Added
 - `ChildResourceType` enum 
 - Test cases for a template resource type

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 // The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
 // The version. This will be added to the end of the Jar and all other resources that are created during the build.
-version = '4.2.0'
+version = '4.3.0'
 // The Java version:
 sourceCompatibility = '11'
 


### PR DESCRIPTION
## Release v4.3.0

Closes out the changelog and bumps the version for the v4.3.0 release. Branched from clean `mainline` per `RELEASE.md`.

### Changed files
- `CHANGELOG.md` — inserted `## [4.3.0] - 2026-07-20` header below the permanent `Unreleased` placeholder
- `build.gradle` — `version` bumped `4.2.0` → `4.3.0`

### Changelog (4.3.0)

**Added**
- `ChildResourceType` enum
- Test cases for a template resource type

### Next steps (per RELEASE.md, done by a human)
- [ ] CI passes on this PR
- [ ] Merge to `mainline`
- [ ] Draft & publish GitHub Release, tag `v4.3.0` (Create new tag on publish), description = changelog entries → triggers Maven Central publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)