### PR TITLE
Add proofs support for getSheet and getReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+### Added
+- `Proof` model and `ProofType` enum
+- `proof` property on rows returned by `getSheet` and `getReport`
+- `PROOFS` inclusion value for `SheetInclusion` and `ReportInclusion`
+
 ## [4.3.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `Proof` model and `ProofType` enum
 - `proof` property on rows returned by `getSheet` and `getReport`
-- `PROOFS` inclusion value for `SheetInclusion` and `ReportInclusion`
+- `PROOFS` inclusion value for `SheetInclusion`, `ReportInclusion`, and `RowInclusion`
 
 ## [4.3.0] - 2026-07-20
 

--- a/src/main/java/com/smartsheet/api/models/AbstractRow.java
+++ b/src/main/java/com/smartsheet/api/models/AbstractRow.java
@@ -83,6 +83,11 @@ public abstract class AbstractRow<TColumn extends Column, TCell extends Cell> ex
     private List<Attachment> attachments;
 
     /**
+     * Represents the proof for this row.
+     */
+    private Proof proof;
+
+    /**
      * Represents the columns for this row.
      */
     private List<TColumn> columns;
@@ -395,6 +400,26 @@ public abstract class AbstractRow<TColumn extends Column, TCell extends Cell> ex
     @SuppressWarnings("unchecked")
     public <T extends AbstractRow<TColumn, TCell>> T setAttachments(List<Attachment> attachments) {
         this.attachments = attachments;
+        return (T) this;
+    }
+
+    /**
+     * Gets the proof.
+     *
+     * @return the proof
+     */
+    public Proof getProof() {
+        return proof;
+    }
+
+    /**
+     * Sets the proof.
+     *
+     * @param proof the new proof
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends AbstractRow<TColumn, TCell>> T setProof(Proof proof) {
+        this.proof = proof;
         return (T) this;
     }
 

--- a/src/main/java/com/smartsheet/api/models/Proof.java
+++ b/src/main/java/com/smartsheet/api/models/Proof.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import com.smartsheet.api.models.enums.ProofType;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Represents the Proof object. A proof is a container that holds attachments and comments for review, editing, or
+ * approval.
+ */
+public class Proof extends NamedModel<Long> {
+
+    /**
+     * Represents the ID of the original proof version.
+     */
+    private Long originalId;
+
+    /**
+     * Represents the type of the proof.
+     */
+    private ProofType type;
+
+    /**
+     * Represents the document type of the proof.
+     */
+    private String documentType;
+
+    /**
+     * Represents the URL used to request the proof.
+     */
+    private String proofRequestUrl;
+
+    /**
+     * Represents the version number of the proof.
+     */
+    private Integer version;
+
+    /**
+     * Represents the date and time the proof was last updated.
+     */
+    private Date lastUpdatedAt;
+
+    /**
+     * The user who last updated the proof.
+     */
+    private User lastUpdatedBy;
+
+    /**
+     * Indicates whether the proof is completed.
+     */
+    private Boolean isCompleted;
+
+    /**
+     * Represents the attachments associated with the proof.
+     */
+    private List<Attachment> attachments;
+
+    /**
+     * Represents the discussions associated with the proof.
+     */
+    private List<Discussion> discussions;
+
+    /**
+     * Provide an 'override' of setName (returns Proof not NamedModel)
+     *
+     * @param name the new name
+     */
+    public Proof setName(String name) {
+        super.setName(name);
+        return this;
+    }
+
+    /**
+     * Gets the ID of the original proof version.
+     *
+     * @return the original id
+     */
+    public Long getOriginalId() {
+        return originalId;
+    }
+
+    /**
+     * Sets the ID of the original proof version.
+     *
+     * @param originalId the new original id
+     */
+    public Proof setOriginalId(Long originalId) {
+        this.originalId = originalId;
+        return this;
+    }
+
+    /**
+     * Gets the type of the proof.
+     *
+     * @return the proof type
+     */
+    public ProofType getType() {
+        return type;
+    }
+
+    /**
+     * Sets the type of the proof.
+     *
+     * @param type the new proof type
+     */
+    public Proof setType(ProofType type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Gets the document type of the proof.
+     *
+     * @return the document type
+     */
+    public String getDocumentType() {
+        return documentType;
+    }
+
+    /**
+     * Sets the document type of the proof.
+     *
+     * @param documentType the new document type
+     */
+    public Proof setDocumentType(String documentType) {
+        this.documentType = documentType;
+        return this;
+    }
+
+    /**
+     * Gets the URL used to request the proof.
+     *
+     * @return the proof request url
+     */
+    public String getProofRequestUrl() {
+        return proofRequestUrl;
+    }
+
+    /**
+     * Sets the URL used to request the proof.
+     *
+     * @param proofRequestUrl the new proof request url
+     */
+    public Proof setProofRequestUrl(String proofRequestUrl) {
+        this.proofRequestUrl = proofRequestUrl;
+        return this;
+    }
+
+    /**
+     * Gets the version number of the proof.
+     *
+     * @return the version
+     */
+    public Integer getVersion() {
+        return version;
+    }
+
+    /**
+     * Sets the version number of the proof.
+     *
+     * @param version the new version
+     */
+    public Proof setVersion(Integer version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Gets the date and time the proof was last updated.
+     *
+     * @return the last updated at
+     */
+    public Date getLastUpdatedAt() {
+        return lastUpdatedAt;
+    }
+
+    /**
+     * Sets the date and time the proof was last updated.
+     *
+     * @param lastUpdatedAt the new last updated at
+     */
+    public Proof setLastUpdatedAt(Date lastUpdatedAt) {
+        this.lastUpdatedAt = lastUpdatedAt;
+        return this;
+    }
+
+    /**
+     * Gets the user who last updated the proof.
+     *
+     * @return the last updated by user
+     */
+    public User getLastUpdatedBy() {
+        return lastUpdatedBy;
+    }
+
+    /**
+     * Sets the user who last updated the proof.
+     *
+     * @param lastUpdatedBy the new last updated by user
+     */
+    public Proof setLastUpdatedBy(User lastUpdatedBy) {
+        this.lastUpdatedBy = lastUpdatedBy;
+        return this;
+    }
+
+    /**
+     * Indicates whether the proof is completed.
+     *
+     * @return the completed status
+     */
+    public Boolean getIsCompleted() {
+        return isCompleted;
+    }
+
+    /**
+     * Sets whether the proof is completed.
+     *
+     * @param isCompleted the new completed status
+     */
+    public Proof setIsCompleted(Boolean isCompleted) {
+        this.isCompleted = isCompleted;
+        return this;
+    }
+
+    /**
+     * Gets the attachments associated with the proof.
+     *
+     * @return the attachments
+     */
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    /**
+     * Sets the attachments associated with the proof.
+     *
+     * @param attachments the new attachments
+     */
+    public Proof setAttachments(List<Attachment> attachments) {
+        this.attachments = attachments;
+        return this;
+    }
+
+    /**
+     * Gets the discussions associated with the proof.
+     *
+     * @return the discussions
+     */
+    public List<Discussion> getDiscussions() {
+        return discussions;
+    }
+
+    /**
+     * Sets the discussions associated with the proof.
+     *
+     * @param discussions the new discussions
+     */
+    public Proof setDiscussions(List<Discussion> discussions) {
+        this.discussions = discussions;
+        return this;
+    }
+}

--- a/src/main/java/com/smartsheet/api/models/enums/ProofType.java
+++ b/src/main/java/com/smartsheet/api/models/enums/ProofType.java
@@ -17,27 +17,12 @@
 package com.smartsheet.api.models.enums;
 
 /**
- * Represents specific objects that can be included in some responses.
+ * Represents the type of a proof.
  */
-public enum ReportInclusion {
-    ATTACHMENTS("attachments"),
-    DISCUSSIONS("discussions"),
-    FORMAT("format"),
-    OBJECTVALUE("objectValue"),
-    PROOFS("proofs"),
-    SCOPE("scope"),
-    SOURCE("source"),
-    SOURCESHEETS("sourceSheets"),
-    SHEETVERSION("sheetVersion");
-
-    String inclusion;
-
-    ReportInclusion(String inclusion) {
-        this.inclusion = inclusion;
-    }
-
-    @Override
-    public String toString() {
-        return inclusion;
-    }
+public enum ProofType {
+    DOCUMENT,
+    IMAGE,
+    MIXED,
+    NONE,
+    VIDEO
 }

--- a/src/main/java/com/smartsheet/api/models/enums/RowInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/RowInclusion.java
@@ -29,6 +29,7 @@ public enum RowInclusion {
     ROW_PERMALINK("rowPermalink"),
     ROW_WRITER_INFO("rowWriterInfo"),
     OBJECT_VALUE("objectValue"),
+    PROOFS("proofs"),
     ;
 
     String inclusion;

--- a/src/main/java/com/smartsheet/api/models/enums/SheetInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/SheetInclusion.java
@@ -30,6 +30,7 @@ public enum SheetInclusion {
     FORMAT("format"),
     OBJECT_VALUE("objectValue"),
     OWNER_INFO("ownerInfo"),
+    PROOFS("proofs"),
     ROW_PERMALINK("rowPermalink"),
     // deprecated, use writerInfo
     ROW_WRITER_INFO("rowWriterInfo"),

--- a/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/ReportResourcesImplTest.java
@@ -27,6 +27,7 @@ import com.smartsheet.api.models.ReportPathNode;
 import com.smartsheet.api.models.FormatDetails;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.PaginationParameters;
+import com.smartsheet.api.models.Proof;
 import com.smartsheet.api.models.Recipient;
 import com.smartsheet.api.models.RecipientEmail;
 import com.smartsheet.api.models.RecipientGroup;
@@ -41,6 +42,7 @@ import com.smartsheet.api.models.enums.PaperSize;
 import com.smartsheet.api.models.enums.ReportAssetType;
 import com.smartsheet.api.models.enums.ReportDestinationType;
 import com.smartsheet.api.models.enums.ReportInclusion;
+import com.smartsheet.api.models.enums.ProofType;
 import com.smartsheet.api.models.enums.SheetEmailFormat;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,11 +77,19 @@ class ReportResourcesImplTest extends ResourcesImplBase {
         server.setResponseBody(new File("src/test/resources/getReport.json"));
         EnumSet<ReportInclusion> reportInclusions = EnumSet.of(
                 ReportInclusion.ATTACHMENTS,
-                ReportInclusion.DISCUSSIONS);
+                ReportInclusion.DISCUSSIONS,
+                ReportInclusion.PROOFS);
         Report report = reportResources.getReport(4583173393803140L, reportInclusions, 1, 1);
         assertThat(report.getPermalink())
                 .isEqualTo("https://app.smartsheet.com/b/home?lx=pWNSDH9itjBXxBzFmyf-5w");
         assertThat(report.getColumns().get(0).getVirtualId()).isEqualTo(4583173393803140L);
+
+        Proof proof = report.getRows().get(0).getProof();
+        assertThat(proof).isNotNull();
+        assertThat(proof.getId()).isEqualTo(8834704717089156L);
+        assertThat(proof.getName()).isEqualTo("Design mockup");
+        assertThat(proof.getType()).isEqualTo(ProofType.IMAGE);
+        assertThat(proof.getIsCompleted()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/smartsheet/api/models/ProofTest.java
+++ b/src/test/java/com/smartsheet/api/models/ProofTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import com.smartsheet.api.internal.json.JacksonJsonSerializer;
+import com.smartsheet.api.models.enums.ProofType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProofTest {
+
+    @Test
+    void testProofGettersAndSetters() {
+        Date now = new Date();
+        User updatedBy = new User();
+        updatedBy.setEmail("user@smartsheet.com");
+        List<Attachment> attachments = new ArrayList<>();
+        List<Discussion> discussions = new ArrayList<>();
+
+        Proof proof = new Proof()
+                .setOriginalId(123L)
+                .setType(ProofType.IMAGE)
+                .setDocumentType("PNG")
+                .setProofRequestUrl("https://app.smartsheet.com/proofs/123")
+                .setVersion(2)
+                .setLastUpdatedAt(now)
+                .setLastUpdatedBy(updatedBy)
+                .setIsCompleted(true)
+                .setAttachments(attachments)
+                .setDiscussions(discussions);
+        proof.setId(456L);
+        proof.setName("My proof");
+
+        assertThat(proof.getId()).isEqualTo(456L);
+        assertThat(proof.getName()).isEqualTo("My proof");
+        assertThat(proof.getOriginalId()).isEqualTo(123L);
+        assertThat(proof.getType()).isEqualTo(ProofType.IMAGE);
+        assertThat(proof.getDocumentType()).isEqualTo("PNG");
+        assertThat(proof.getProofRequestUrl()).isEqualTo("https://app.smartsheet.com/proofs/123");
+        assertThat(proof.getVersion()).isEqualTo(2);
+        assertThat(proof.getLastUpdatedAt()).isEqualTo(now);
+        assertThat(proof.getLastUpdatedBy()).isEqualTo(updatedBy);
+        assertThat(proof.getIsCompleted()).isTrue();
+        assertThat(proof.getAttachments()).isSameAs(attachments);
+        assertThat(proof.getDiscussions()).isSameAs(discussions);
+    }
+
+    @Test
+    void testProofSerializesTypeAndIsCompletedWithWireNames() throws Exception {
+        Proof proof = new Proof().setType(ProofType.DOCUMENT).setIsCompleted(false);
+
+        String json = new JacksonJsonSerializer().serialize(proof);
+
+        assertThat(json).contains("\"type\":\"DOCUMENT\"");
+        assertThat(json).contains("\"isCompleted\":false");
+    }
+}

--- a/src/test/java/com/smartsheet/api/sdktest/RowTest.java
+++ b/src/test/java/com/smartsheet/api/sdktest/RowTest.java
@@ -25,11 +25,15 @@ import com.smartsheet.api.models.Hyperlink;
 import com.smartsheet.api.models.PagedResult;
 import com.smartsheet.api.models.Predecessor;
 import com.smartsheet.api.models.PredecessorList;
+import com.smartsheet.api.models.Proof;
 import com.smartsheet.api.models.Row;
 import com.smartsheet.api.models.Sheet;
+import com.smartsheet.api.models.enums.ProofType;
+import com.smartsheet.api.models.enums.RowInclusion;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +45,26 @@ class RowTest {
         Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
         PagedResult<Sheet> sheets = ss.sheetResources().listSheets();
         assertThat(sheets.getData().get(0).getName()).isEqualTo("Copy of Sample Sheet");
+    }
+
+    @Test
+    void getRow_Serialization_Proof() throws SmartsheetException {
+        Smartsheet ss = HelperFunctions.SetupClient("Serialization - Proof");
+
+        Row row = ss.sheetResources().rowResources().getRow(1, 2, EnumSet.of(RowInclusion.PROOFS), null);
+
+        Proof proof = row.getProof();
+        assertThat(proof).isNotNull();
+        assertThat(proof.getId()).isEqualTo(100L);
+        assertThat(proof.getOriginalId()).isEqualTo(100L);
+        assertThat(proof.getName()).isEqualTo("Sample Proof Document");
+        assertThat(proof.getType()).isEqualTo(ProofType.IMAGE);
+        assertThat(proof.getDocumentType()).isEqualTo("NONE");
+        assertThat(proof.getProofRequestUrl())
+                .isEqualTo("https://app.smartsheet.com/b/proofs/sheets/test123/proofs/proof456");
+        assertThat(proof.getVersion()).isEqualTo(1);
+        assertThat(proof.getLastUpdatedBy().getEmail()).isEqualTo("john.doe@smartsheet.com");
+        assertThat(proof.getIsCompleted()).isFalse();
     }
 
     @Test

--- a/src/test/resources/getReport.json
+++ b/src/test/resources/getReport.json
@@ -45,7 +45,18 @@
           "value": "In Progress",
           "displayValue": "In Progress"
         }
-      ]
+      ],
+      "proof": {
+        "id": 8834704717089156,
+        "originalId": 8834704717089156,
+        "name": "Design mockup",
+        "type": "IMAGE",
+        "documentType": "PNG",
+        "proofRequestUrl": "https://app.smartsheet.com/proofs/8834704717089156",
+        "version": 1,
+        "lastUpdatedAt": "2014-10-02T15:05:35Z",
+        "isCompleted": false
+      }
     }
 
   ]


### PR DESCRIPTION
Adds `proofs` inclusion support to `getSheet` and `getReport`.

## Changes
- New `Proof` model (`com.smartsheet.api.models.Proof`) and `ProofType` enum (`DOCUMENT, IMAGE, MIXED, NONE, VIDEO`)
- Added `proof` property to `AbstractRow`, so it surfaces on both `Row` and `ReportRow`
- Added `PROOFS` include value to `SheetInclusion` and `ReportInclusion`
- Unit test for `Proof` (getters/setters + wire-name serialization) and extended `ReportResourcesImplTest` to assert row-level `proof` deserialization
- CHANGELOG entry under Unreleased

No changes needed to method signatures or query serialization — the new enum value flows through `QueryUtil` and serializes to `proofs` automatically.

DEVECO-2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new `Proof` model and `ProofType` enum.
  * Rows returned from sheet and report retrieval can now include proof metadata when requested.
  * Added `PROOFS` inclusion options for sheets, reports, and rows.

* **Tests**
  * Expanded unit and serialization tests to validate proof fields and JSON output.
  * Updated report/row fixtures and assertions for proof-enabled responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->