### PR TITLE
Add report column builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Proof` model and `ProofType` enum
 - `proof` property on rows returned by `getSheet` and `getReport`
 - `PROOFS` inclusion value for `SheetInclusion`, `ReportInclusion`, and `RowInclusion`
+- `ReportColumn.AddReportColumnBuilder` for constructing report columns
 
 ## [4.3.0] - 2026-07-20
 

--- a/src/main/java/com/smartsheet/api/models/ReportColumn.java
+++ b/src/main/java/com/smartsheet/api/models/ReportColumn.java
@@ -16,6 +16,13 @@
 
 package com.smartsheet.api.models;
 
+import com.smartsheet.api.models.enums.ColumnType;
+import com.smartsheet.api.models.enums.Symbol;
+import com.smartsheet.api.models.enums.SystemColumnType;
+import com.smartsheet.api.models.format.Format;
+
+import java.util.List;
+
 /**
  * Represents the “virtual” Column object for Report.
  */
@@ -68,5 +75,289 @@ public class ReportColumn extends Column {
     public ReportColumn setVirtualId(Long virtualId) {
         this.virtualId = virtualId;
         return this;
+    }
+
+    /**
+     * A convenience class to help create a ReportColumn object with the appropriate fields for adding to a report.
+     */
+    public static class AddReportColumnBuilder {
+        private String title;
+        private Integer index;
+        private ColumnType type;
+        private List<String> options;
+        private Symbol symbol;
+        private SystemColumnType systemColumnType;
+        private AutoNumberFormat autoNumberFormat;
+        private Integer width;
+        private Boolean primary;
+        private Format format;
+        private Boolean validation;
+        private boolean sheetNameColumn;
+
+        /**
+         * Sets the title for the column.
+         *
+         * @param title the title
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setTitle(String title) {
+            this.title = title;
+            return this;
+        }
+
+        /**
+         * Gets the title.
+         *
+         * @return the title
+         */
+        public String getTitle() {
+            return title;
+        }
+
+        /**
+         * Sets the index for the column.
+         *
+         * @param index the index
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setIndex(Integer index) {
+            this.index = index;
+            return this;
+        }
+
+        /**
+         * Gets the index.
+         *
+         * @return the index
+         */
+        public Integer getIndex() {
+            return index;
+        }
+
+        /**
+         * Sets the type for the column.
+         *
+         * @param type the type
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setType(ColumnType type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Gets the type.
+         *
+         * @return the type
+         */
+        public ColumnType getType() {
+            return type;
+        }
+
+        /**
+         * Sets the options for the column.
+         *
+         * @param options the options
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setOptions(List<String> options) {
+            this.options = options;
+            return this;
+        }
+
+        /**
+         * Gets the options.
+         *
+         * @return the options
+         */
+        public List<String> getOptions() {
+            return options;
+        }
+
+        /**
+         * Sets the symbol for the column.
+         *
+         * @param symbol the symbol
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setSymbol(Symbol symbol) {
+            this.symbol = symbol;
+            return this;
+        }
+
+        /**
+         * Gets the symbol.
+         *
+         * @return the symbol
+         */
+        public Symbol getSymbol() {
+            return symbol;
+        }
+
+        /**
+         * Sets the system column type.
+         *
+         * @param systemColumnType the system column type
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setSystemColumnType(SystemColumnType systemColumnType) {
+            this.systemColumnType = systemColumnType;
+            return this;
+        }
+
+        /**
+         * Gets the system column type.
+         *
+         * @return the system column type
+         */
+        public SystemColumnType getSystemColumnType() {
+            return systemColumnType;
+        }
+
+        /**
+         * Sets the format for an auto number column.
+         *
+         * @param autoNumberFormat the auto number format
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setAutoNumberFormat(AutoNumberFormat autoNumberFormat) {
+            this.autoNumberFormat = autoNumberFormat;
+            return this;
+        }
+
+        /**
+         * Gets the auto number format.
+         *
+         * @return the auto number format
+         */
+        public AutoNumberFormat getAutoNumberFormat() {
+            return autoNumberFormat;
+        }
+
+        /**
+         * Sets the width for the column.
+         *
+         * @param width the width
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setWidth(Integer width) {
+            this.width = width;
+            return this;
+        }
+
+        /**
+         * Gets the width.
+         *
+         * @return the width
+         */
+        public Integer getWidth() {
+            return width;
+        }
+
+        /**
+         * Sets the primary flag for the column.
+         *
+         * @param primary the primary flag
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setPrimary(Boolean primary) {
+            this.primary = primary;
+            return this;
+        }
+
+        /**
+         * Gets the primary flag.
+         *
+         * @return the primary flag
+         */
+        public Boolean getPrimary() {
+            return primary;
+        }
+
+        /**
+         * Sets the format for the column.
+         *
+         * @param format the format
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setFormat(Format format) {
+            this.format = format;
+            return this;
+        }
+
+        /**
+         * Gets the format.
+         *
+         * @return the format
+         */
+        public Format getFormat() {
+            return format;
+        }
+
+        /**
+         * Sets the validation flag for the column.
+         *
+         * @param validation the validation flag
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setValidation(Boolean validation) {
+            this.validation = validation;
+            return this;
+        }
+
+        /**
+         * Gets the validation flag.
+         *
+         * @return the validation flag
+         */
+        public Boolean getValidation() {
+            return validation;
+        }
+
+        /**
+         * Sets the sheet name column flag.
+         *
+         * @param sheetNameColumn the sheet name column flag
+         * @return the AddReportColumnBuilder
+         */
+        public AddReportColumnBuilder setSheetNameColumn(boolean sheetNameColumn) {
+            this.sheetNameColumn = sheetNameColumn;
+            return this;
+        }
+
+        /**
+         * Gets the sheet name column flag.
+         *
+         * @return the sheet name column flag
+         */
+        public boolean getSheetNameColumn() {
+            return sheetNameColumn;
+        }
+
+        /**
+         * Builds the ReportColumn.
+         *
+         * @return the ReportColumn
+         */
+        public ReportColumn build() {
+            if (title == null || type == null) {
+                throw new InstantiationError();
+            }
+
+            ReportColumn column = new ReportColumn();
+            column.setTitle(title);
+            column.setType(type);
+            column.setIndex(index);
+            column.setOptions(options);
+            column.setSymbol(symbol);
+            column.setSystemColumnType(systemColumnType);
+            column.setAutoNumberFormat(autoNumberFormat);
+            column.setWidth(width);
+            column.setPrimary(primary);
+            column.setFormat(format);
+            column.setValidation(validation);
+            column.setSheetNameColumn(sheetNameColumn);
+            return column;
+        }
     }
 }

--- a/src/test/java/com/smartsheet/api/models/ReportColumnTest.java
+++ b/src/test/java/com/smartsheet/api/models/ReportColumnTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import com.smartsheet.api.models.enums.ColumnType;
+import com.smartsheet.api.models.enums.SystemColumnType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReportColumnTest {
+
+    @Test
+    void testAddReportColumnBuilder() {
+        AutoNumberFormat autoNumberFormat = new AutoNumberFormat();
+        autoNumberFormat.setPrefix("TASK-");
+
+        ReportColumn column = new ReportColumn.AddReportColumnBuilder()
+                .setTitle("Sheet name")
+                .setType(ColumnType.TEXT_NUMBER)
+                .setIndex(5)
+                .setSheetNameColumn(true)
+                .setOptions(List.of("a", "b"))
+                .setSymbol(null)
+                .setSystemColumnType(SystemColumnType.AUTO_NUMBER)
+                .setAutoNumberFormat(autoNumberFormat)
+                .setWidth(150)
+                .setPrimary(false)
+                .setFormat(null)
+                .setValidation(false)
+                .build();
+
+        assertThat(column.getTitle()).isEqualTo("Sheet name");
+        assertThat(column.getType()).isEqualTo(ColumnType.TEXT_NUMBER);
+        assertThat(column.getIndex()).isEqualTo(5);
+        assertThat(column.getSheetNameColumn()).isTrue();
+        assertThat(column.getOptions()).containsExactly("a", "b");
+        assertThat(column.getSystemColumnType()).isEqualTo(SystemColumnType.AUTO_NUMBER);
+        assertThat(column.getAutoNumberFormat()).isEqualTo(autoNumberFormat);
+        assertThat(column.getWidth()).isEqualTo(150);
+        assertThat(column.getPrimary()).isFalse();
+        assertThat(column.getValidation()).isFalse();
+    }
+
+    @Test
+    void testAddReportColumnBuilderDefaultsSheetNameColumnFalse() {
+        ReportColumn column = new ReportColumn.AddReportColumnBuilder()
+                .setTitle("Item selected")
+                .setType(ColumnType.CHECKBOX)
+                .build();
+
+        assertThat(column.getSheetNameColumn()).isFalse();
+    }
+
+    @Test
+    void testAddReportColumnBuilderThrowsWhenTitleMissing() {
+        assertThrows(InstantiationError.class, () ->
+                new ReportColumn.AddReportColumnBuilder()
+                        .setType(ColumnType.CHECKBOX)
+                        .build());
+    }
+
+    @Test
+    void testAddReportColumnBuilderThrowsWhenTypeMissing() {
+        assertThrows(InstantiationError.class, () ->
+                new ReportColumn.AddReportColumnBuilder()
+                        .setTitle("Item selected")
+                        .build());
+    }
+}

--- a/src/test/java/com/smartsheet/api/sdktest/reports/TestAddReportColumns.java
+++ b/src/test/java/com/smartsheet/api/sdktest/reports/TestAddReportColumns.java
@@ -178,17 +178,19 @@ public class TestAddReportColumns {
 
     @BeforeEach
     void setUp() {
-        ReportColumn column1 = new ReportColumn();
-        column1.setTitle("Item selected");
-        column1.setType(ColumnType.CHECKBOX);
-        column1.setIndex(4);
-        column1.setSheetNameColumn(false);
+        ReportColumn column1 = new ReportColumn.AddReportColumnBuilder()
+                .setTitle("Item selected")
+                .setType(ColumnType.CHECKBOX)
+                .setIndex(4)
+                .setSheetNameColumn(false)
+                .build();
 
-        ReportColumn column2 = new ReportColumn();
-        column2.setTitle("Sheet name");
-        column2.setType(ColumnType.TEXT_NUMBER);
-        column2.setIndex(5);
-        column2.setSheetNameColumn(true);
+        ReportColumn column2 = new ReportColumn.AddReportColumnBuilder()
+                .setTitle("Sheet name")
+                .setType(ColumnType.TEXT_NUMBER)
+                .setIndex(5)
+                .setSheetNameColumn(true)
+                .build();
 
         testColumns = new ArrayList<>();
         testColumns.add(column1);


### PR DESCRIPTION
# Pull Request

## Summary

Adds ReportColumn.AddReportColumnBuilder - a fluent builder for constructing ReportColumn objects when adding columns to a report. The builder enforces required fields (title and type), throwing InstantiationError if either is missing at build time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fluent builder for creating report columns with configurable titles, types, ordering, options, symbols, system column settings, auto-number format, width, primary flag, formatting, validation, and sheet-name behavior.
  * Added validation so required column details (title and type) must be provided before a column can be created.
* **Tests**
  * Added unit test coverage for builder configuration, defaults, and required-field validation.
  * Updated existing report-column test setup to use the new builder.
* **Documentation**
  * Updated the Unreleased changelog to mention the new builder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->