### PR TITLE
Add COMMENTER value to AccessLevel enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PROOFS` inclusion value for `SheetInclusion`, `ReportInclusion`, and `RowInclusion`
 - `ReportColumn.AddReportColumnBuilder` for constructing report columns
 
+### Fixed
+- `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares. Fixes [smartsheet-csharp-sdk#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)
+
 ## [4.3.0] - 2026-07-20
 
 ### Added

--- a/src/main/java/com/smartsheet/api/models/enums/AccessLevel.java
+++ b/src/main/java/com/smartsheet/api/models/enums/AccessLevel.java
@@ -26,5 +26,6 @@ public enum AccessLevel {
     EDITOR,
     EDITOR_SHARE,
     ADMIN,
-    OWNER
+    OWNER,
+    COMMENTER
 }

--- a/src/main/java/com/smartsheet/api/models/enums/AccessLevel.java
+++ b/src/main/java/com/smartsheet/api/models/enums/AccessLevel.java
@@ -19,13 +19,13 @@ package com.smartsheet.api.models.enums;
 /**
  * Represents access levels that users can have.
  *
- * @see <a href="https://smartsheet.redoc.ly/#section/Security/Access-Levels">Access Level Help</a>
+ * @see <a href="https://developers.smartsheet.com/api/smartsheet/guides/basics/resource-access-levels">Resource Access Levels</a>
  */
 public enum AccessLevel {
     VIEWER,
+    COMMENTER,
     EDITOR,
     EDITOR_SHARE,
     ADMIN,
-    OWNER,
-    COMMENTER
+    OWNER
 }

--- a/src/test/java/com/smartsheet/api/internal/json/AccessLevelDeserializationTest.java
+++ b/src/test/java/com/smartsheet/api/internal/json/AccessLevelDeserializationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.internal.json;
+
+import com.smartsheet.api.models.Report;
+import com.smartsheet.api.models.Sheet;
+import com.smartsheet.api.models.ShareResponse;
+import com.smartsheet.api.models.Workspace;
+import com.smartsheet.api.models.enums.AccessLevel;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a COMMENTER access level returned by the API deserializes to
+ * {@link AccessLevel#COMMENTER} rather than silently becoming null.
+ *
+ * <p>The serializer sets READ_UNKNOWN_ENUM_VALUES_AS_NULL, so an access level missing from the
+ * enum is dropped without an error, leaving callers unable to tell "this is a Commenter share"
+ * apart from "this share has no access level". See
+ * <a href="https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218">csharp-sdk#218</a>.
+ */
+class AccessLevelDeserializationTest {
+    JacksonJsonSerializer jjs = new JacksonJsonSerializer();
+
+    @Test
+    void shareResponseDeserializesCommenter() throws JSONSerializerException, IOException {
+        ShareResponse share = deserialize(
+                "{\"accessLevel\":\"COMMENTER\",\"email\":\"user@example.com\"}",
+                ShareResponse.class
+        );
+
+        assertThat(share.getAccessLevel()).isEqualTo(AccessLevel.COMMENTER);
+        assertThat(share.getEmail()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void sheetDeserializesCommenter() throws JSONSerializerException, IOException {
+        Sheet sheet = deserialize("{\"accessLevel\":\"COMMENTER\"}", Sheet.class);
+
+        assertThat(sheet.getAccessLevel()).isEqualTo(AccessLevel.COMMENTER);
+    }
+
+    @Test
+    void reportDeserializesCommenter() throws JSONSerializerException, IOException {
+        Report report = deserialize("{\"accessLevel\":\"COMMENTER\"}", Report.class);
+
+        assertThat(report.getAccessLevel()).isEqualTo(AccessLevel.COMMENTER);
+    }
+
+    @Test
+    void workspaceDeserializesCommenter() throws JSONSerializerException, IOException {
+        Workspace workspace = deserialize("{\"accessLevel\":\"COMMENTER\"}", Workspace.class);
+
+        assertThat(workspace.getAccessLevel()).isEqualTo(AccessLevel.COMMENTER);
+    }
+
+    @Test
+    void unmappedAccessLevelStillDeserializesToNull() throws JSONSerializerException, IOException {
+        // Forward-compatibility is intentional: an access level this SDK version does not know
+        // must not fail the whole response.
+        Sheet sheet = deserialize("{\"accessLevel\":\"NOT_A_REAL_ACCESS_LEVEL\"}", Sheet.class);
+
+        assertThat(sheet.getAccessLevel()).isNull();
+    }
+
+    private <T> T deserialize(String json, Class<T> objectClass) throws JSONSerializerException, IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+            return jjs.deserialize(objectClass, in);
+        }
+    }
+}

--- a/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
+++ b/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
@@ -30,6 +30,7 @@ class AccessLevelTest {
         assertThat(AccessLevel.valueOf("EDITOR_SHARE")).isNotNull();
         assertThat(AccessLevel.valueOf("ADMIN")).isNotNull();
         assertThat(AccessLevel.valueOf("OWNER")).isNotNull();
-        assertThat(AccessLevel.values()).hasSize(5);
+        assertThat(AccessLevel.valueOf("COMMENTER")).isNotNull();
+        assertThat(AccessLevel.values()).hasSize(6);
     }
 }

--- a/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
+++ b/src/test/java/com/smartsheet/api/models/AccessLevelTest.java
@@ -33,4 +33,16 @@ class AccessLevelTest {
         assertThat(AccessLevel.valueOf("COMMENTER")).isNotNull();
         assertThat(AccessLevel.values()).hasSize(6);
     }
+
+    @Test
+    void declarationOrderMatchesSpecification() {
+        assertThat(AccessLevel.values()).containsExactly(
+                AccessLevel.VIEWER,
+                AccessLevel.COMMENTER,
+                AccessLevel.EDITOR,
+                AccessLevel.EDITOR_SHARE,
+                AccessLevel.ADMIN,
+                AccessLevel.OWNER
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds the missing `COMMENTER` value to `com.smartsheet.api.models.enums.AccessLevel`.

Fixes smartsheet/smartsheet-csharp-sdk#218, which reports this against the C# SDK. The Java SDK had the identical gap, and the maintainer response on that issue committed to fixing both.

## Problem

The [Access Level schema](https://developers.smartsheet.com/api/smartsheet/guides/basics/resource-access-levels) documents six values, but the enum defined only five — `COMMENTER` was absent.

`JacksonJsonSerializer` sets `READ_UNKNOWN_ENUM_VALUES_AS_NULL`, so a Commenter access level was dropped silently: the object came back fully populated with `accessLevel == null`, no exception and no warning. Callers could not distinguish "this share is Commenter" from "this share has no access level". This affected `ShareResponse`, `Sheet`, `Report`, `Workspace`, and every other model carrying an `accessLevel`.

Unlike C#, the write path was not separately broken here — `accessLevel` fields are reference types — but `CreateShareRequest` and `UpdateShareRequest` still had no `COMMENTER` value to set.

## Changes

- Added `COMMENTER` to the `AccessLevel` enum, declared after `VIEWER` to match the order in the API specification (and the Python SDK).
- Updated the stale `smartsheet.redoc.ly` javadoc link to the current Resource Access Levels guide.
- Updated `AccessLevelTest` for the new value and count, and pinned the declaration order so it cannot drift from the spec.
- Added `AccessLevelDeserializationTest` covering `ShareResponse`, `Sheet`, `Report`, and `Workspace`.

Forward-compatibility is deliberately preserved: a genuinely unknown access level still deserializes to `null` rather than failing the response. That behavior is now pinned by a test.

## Testing

- `./gradlew test` — 659/661 pass. The 2 failures are `LoggingIT` integration tests that require a live API connection and fail identically on clean `mainline` in this environment.
- Checkstyle: no new violations (the 3 reported errors are pre-existing, in `ReportResources`/`ReportResourcesImpl`).

## Note

The C# counterpart is smartsheet/smartsheet-csharp-sdk#219. Python and JavaScript already had `COMMENTER`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `COMMENTER` access level was incorrectly deserialized as `null` for sheets, reports, workspaces, and shares.
* **Documentation**
  * Updated access-level documentation links to reference the current resource access levels guide.
* **Changelog**
  * Added an unreleased entry documenting the access-level deserialization fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->