### PR TITLE
Support include=planName on List User Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `proof` property on rows returned by `getSheet` and `getReport`
 - `PROOFS` inclusion value for `SheetInclusion`, `ReportInclusion`, and `RowInclusion`
 - `ReportColumn.AddReportColumnBuilder` for constructing report columns
-- Support for the `include` query parameter on GET /2.0/users/{userId}/plans via a new `UserResources.listUserPlans` overload, along with a `UserPlanInclusion` enum whose only value is `PLAN_NAMES`
-- `planName` property on `UserPlan`, populated when `PLAN_NAMES` is requested
+- Support for the `include` query parameter on GET /2.0/users/{userId}/plans via a new `UserResources.listUserPlans` overload, along with a `UserPlanInclusion` enum whose only value is `PLAN_NAME`
+- `planName` property on `UserPlan`, populated when `PLAN_NAME` is requested
 
 ### Fixed
 - `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares. Fixes [smartsheet-csharp-sdk#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `proof` property on rows returned by `getSheet` and `getReport`
 - `PROOFS` inclusion value for `SheetInclusion`, `ReportInclusion`, and `RowInclusion`
 - `ReportColumn.AddReportColumnBuilder` for constructing report columns
+- Support for the `include` query parameter on GET /2.0/users/{userId}/plans via a new `UserResources.listUserPlans` overload, along with a `UserPlanInclusion` enum whose only value is `PLAN_NAMES`
+- `planName` property on `UserPlan`, populated when `PLAN_NAMES` is requested
 
 ### Fixed
 - `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares. Fixes [smartsheet-csharp-sdk#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)

--- a/src/main/java/com/smartsheet/api/UserResources.java
+++ b/src/main/java/com/smartsheet/api/UserResources.java
@@ -288,11 +288,11 @@ public interface UserResources {
      * @param lastKey lastKey from previous response to get next page of results
      * @param maxItems maximum number of items to return
      * @param displayContributorSeatType if true, returns CONTRIBUTOR instead of VIEWER for eligible users
-     * @param includes elements to include in the response. Specifying
-     *                 {@link UserPlanInclusion#PLAN_NAME} populates {@link UserPlan#getPlanName()}
-     *                 with the name of the organization that owns each plan. Organization names are
-     *                 cached server side for several hours, so a recently renamed organization may
-     *                 briefly report its previous name.
+     * @param include elements to include in the response. Specifying
+     *                {@link UserPlanInclusion#PLAN_NAME} populates {@link UserPlan#getPlanName()}
+     *                with the name of the organization that owns each plan. Organization names are
+     *                cached server side for several hours, so a recently renamed organization may
+     *                briefly report its previous name.
      * @return UserPlansResponse json response
      * @throws IllegalArgumentException    if any argument is null or empty string
      * @throws InvalidRequestException     if there is any problem with the REST API request
@@ -306,7 +306,7 @@ public interface UserResources {
             String lastKey,
             Long maxItems,
             Boolean displayContributorSeatType,
-            EnumSet<UserPlanInclusion> includes
+            EnumSet<UserPlanInclusion> include
     ) throws SmartsheetException;
 
     /**

--- a/src/main/java/com/smartsheet/api/UserResources.java
+++ b/src/main/java/com/smartsheet/api/UserResources.java
@@ -289,7 +289,7 @@ public interface UserResources {
      * @param maxItems maximum number of items to return
      * @param displayContributorSeatType if true, returns CONTRIBUTOR instead of VIEWER for eligible users
      * @param includes elements to include in the response. Specifying
-     *                 {@link UserPlanInclusion#PLAN_NAMES} populates {@link UserPlan#getPlanName()}
+     *                 {@link UserPlanInclusion#PLAN_NAME} populates {@link UserPlan#getPlanName()}
      *                 with the name of the organization that owns each plan. Organization names are
      *                 cached server side for several hours, so a recently renamed organization may
      *                 briefly report its previous name.

--- a/src/main/java/com/smartsheet/api/UserResources.java
+++ b/src/main/java/com/smartsheet/api/UserResources.java
@@ -30,6 +30,7 @@ import com.smartsheet.api.models.enums.SeatType;
 import com.smartsheet.api.models.enums.UpgradeSeatType;
 import com.smartsheet.api.models.enums.DowngradeSeatType;
 import com.smartsheet.api.models.enums.UserInclusion;
+import com.smartsheet.api.models.enums.UserPlanInclusion;
 
 import java.io.FileNotFoundException;
 import java.util.Date;
@@ -276,6 +277,36 @@ public interface UserResources {
             String lastKey,
             Long maxItems,
             Boolean displayContributorSeatType
+    ) throws SmartsheetException;
+
+    /**
+     * <p>Fetch all user's plans.</p>
+     *
+     * <p>It mirrors to the following Smartsheet REST API method: GET /users/{userId}/plans</p>
+     *
+     * @param userId the id of the user whose plans to fetch
+     * @param lastKey lastKey from previous response to get next page of results
+     * @param maxItems maximum number of items to return
+     * @param displayContributorSeatType if true, returns CONTRIBUTOR instead of VIEWER for eligible users
+     * @param includes elements to include in the response. Specifying
+     *                 {@link UserPlanInclusion#PLAN_NAMES} populates {@link UserPlan#getPlanName()}
+     *                 with the name of the organization that owns each plan. Organization names are
+     *                 cached server side for several hours, so a recently renamed organization may
+     *                 briefly report its previous name.
+     * @return UserPlansResponse json response
+     * @throws IllegalArgumentException    if any argument is null or empty string
+     * @throws InvalidRequestException     if there is any problem with the REST API request
+     * @throws AuthorizationException      if there is any problem with  the REST API authorization (access token)
+     * @throws ResourceNotFoundException   if the resource cannot be found
+     * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
+     * @throws SmartsheetException         if there is any other error during the operation
+     */
+    TokenPaginatedResult<UserPlan> listUserPlans(
+            long userId,
+            String lastKey,
+            Long maxItems,
+            Boolean displayContributorSeatType,
+            EnumSet<UserPlanInclusion> includes
     ) throws SmartsheetException;
 
     /**

--- a/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
@@ -43,6 +43,7 @@ import com.smartsheet.api.models.enums.SeatType;
 import com.smartsheet.api.models.enums.UpgradeSeatType;
 import com.smartsheet.api.models.enums.DowngradeSeatType;
 import com.smartsheet.api.models.enums.UserInclusion;
+import com.smartsheet.api.models.enums.UserPlanInclusion;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -661,6 +662,39 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
             Long maxItems,
             Boolean displayContributorSeatType
     ) throws SmartsheetException {
+        return listUserPlans(userId, lastKey, maxItems, displayContributorSeatType, null);
+    }
+
+    /**
+     * <p>Fetch all user's plans.</p>
+     *
+     * <p>It mirrors to the following Smartsheet REST API method: GET /users/{userId}/plans</p>
+     *
+     * @param userId the id of the user whose plans to fetch
+     * @param lastKey lastKey from previous response to get next page of results
+     * @param maxItems maximum number of items to return
+     * @param displayContributorSeatType if true, returns CONTRIBUTOR instead of VIEWER for eligible users
+     * @param includes elements to include in the response. Specifying
+     *                 {@link UserPlanInclusion#PLAN_NAMES} populates {@link UserPlan#getPlanName()}
+     *                 with the name of the organization that owns each plan. Organization names are
+     *                 cached server side for several hours, so a recently renamed organization may
+     *                 briefly report its previous name.
+     * @return UserPlansResponse json response
+     * @throws IllegalArgumentException    if any argument is null or empty string
+     * @throws InvalidRequestException     if there is any problem with the REST API request
+     * @throws AuthorizationException      if there is any problem with  the REST API authorization (access token)
+     * @throws ResourceNotFoundException   if the resource cannot be found
+     * @throws ServiceUnavailableException if the REST API service is not available (possibly due to rate limiting)
+     * @throws SmartsheetException         if there is any other error during the operation
+     */
+    @Override
+    public TokenPaginatedResult<UserPlan> listUserPlans(
+            long userId,
+            String lastKey,
+            Long maxItems,
+            Boolean displayContributorSeatType,
+            EnumSet<UserPlanInclusion> includes
+    ) throws SmartsheetException {
 
         String path = USERS + "/" + userId + "/plans";
         Map<String, Object> parameters = new HashMap<>();
@@ -675,6 +709,10 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
 
         if (displayContributorSeatType != null) {
             parameters.put("displayContributorSeatType", displayContributorSeatType);
+        }
+
+        if (includes != null) {
+            parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
         }
 
         path += QueryUtil.generateUrl(null, parameters);

--- a/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
@@ -674,11 +674,11 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @param lastKey lastKey from previous response to get next page of results
      * @param maxItems maximum number of items to return
      * @param displayContributorSeatType if true, returns CONTRIBUTOR instead of VIEWER for eligible users
-     * @param includes elements to include in the response. Specifying
-     *                 {@link UserPlanInclusion#PLAN_NAME} populates {@link UserPlan#getPlanName()}
-     *                 with the name of the organization that owns each plan. Organization names are
-     *                 cached server side for several hours, so a recently renamed organization may
-     *                 briefly report its previous name.
+     * @param include elements to include in the response. Specifying
+     *                {@link UserPlanInclusion#PLAN_NAME} populates {@link UserPlan#getPlanName()}
+     *                with the name of the organization that owns each plan. Organization names are
+     *                cached server side for several hours, so a recently renamed organization may
+     *                briefly report its previous name.
      * @return UserPlansResponse json response
      * @throws IllegalArgumentException    if any argument is null or empty string
      * @throws InvalidRequestException     if there is any problem with the REST API request
@@ -693,7 +693,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
             String lastKey,
             Long maxItems,
             Boolean displayContributorSeatType,
-            EnumSet<UserPlanInclusion> includes
+            EnumSet<UserPlanInclusion> include
     ) throws SmartsheetException {
 
         String path = USERS + "/" + userId + "/plans";
@@ -711,8 +711,8 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
             parameters.put("displayContributorSeatType", displayContributorSeatType);
         }
 
-        if (includes != null) {
-            parameters.put("include", QueryUtil.generateCommaSeparatedList(includes));
+        if (include != null) {
+            parameters.put("include", QueryUtil.generateCommaSeparatedList(include));
         }
 
         path += QueryUtil.generateUrl(null, parameters);

--- a/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java
@@ -675,7 +675,7 @@ public class UserResourcesImpl extends AbstractResources implements UserResource
      * @param maxItems maximum number of items to return
      * @param displayContributorSeatType if true, returns CONTRIBUTOR instead of VIEWER for eligible users
      * @param includes elements to include in the response. Specifying
-     *                 {@link UserPlanInclusion#PLAN_NAMES} populates {@link UserPlan#getPlanName()}
+     *                 {@link UserPlanInclusion#PLAN_NAME} populates {@link UserPlan#getPlanName()}
      *                 with the name of the organization that owns each plan. Organization names are
      *                 cached server side for several hours, so a recently renamed organization may
      *                 briefly report its previous name.

--- a/src/main/java/com/smartsheet/api/models/UserPlan.java
+++ b/src/main/java/com/smartsheet/api/models/UserPlan.java
@@ -24,6 +24,7 @@ import com.smartsheet.api.models.enums.SeatType;
  */
 public class UserPlan {
     private Long planId;
+    private String planName;
     private SeatType seatType;
     private ZonedDateTime seatTypeLastChangedAt;
     private ZonedDateTime provisionalExpirationDate;
@@ -35,6 +36,26 @@ public class UserPlan {
 
     public void setPlanId(Long planId) {
         this.planId = planId;
+    }
+
+    /**
+     * <p>The name of the organization that owns this plan.</p>
+     *
+     * <p>Only populated when {@code planNames} was requested via the {@code include} parameter of
+     * {@code listUserPlans}. It is also null for a plan whose owning organization has no name, so
+     * a null value does not by itself mean the enrichment was not requested.</p>
+     *
+     * <p>Organization names are cached server side for several hours, so a recently renamed
+     * organization may briefly report its previous name.</p>
+     *
+     * @return the plan name, or null
+     */
+    public String getPlanName() {
+        return planName;
+    }
+
+    public void setPlanName(String planName) {
+        this.planName = planName;
     }
 
     public SeatType getSeatType() {

--- a/src/main/java/com/smartsheet/api/models/UserPlan.java
+++ b/src/main/java/com/smartsheet/api/models/UserPlan.java
@@ -41,7 +41,7 @@ public class UserPlan {
     /**
      * <p>The name of the organization that owns this plan.</p>
      *
-     * <p>Only populated when {@code planNames} was requested via the {@code include} parameter of
+     * <p>Only populated when {@code planName} was requested via the {@code include} parameter of
      * {@code listUserPlans}. It is also null for a plan whose owning organization has no name, so
      * a null value does not by itself mean the enrichment was not requested.</p>
      *

--- a/src/main/java/com/smartsheet/api/models/enums/UserPlanInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/UserPlanInclusion.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models.enums;
+
+/**
+ * Represents specific objects that can be included with the ListUserPlans request.
+ */
+public enum UserPlanInclusion {
+    PLAN_NAMES("planNames"),
+    ;
+
+    String inclusion;
+
+    UserPlanInclusion(String inclusion) {
+        this.inclusion = inclusion;
+    }
+
+    @Override
+    public String toString() {
+        return inclusion;
+    }
+}

--- a/src/main/java/com/smartsheet/api/models/enums/UserPlanInclusion.java
+++ b/src/main/java/com/smartsheet/api/models/enums/UserPlanInclusion.java
@@ -20,7 +20,7 @@ package com.smartsheet.api.models.enums;
  * Represents specific objects that can be included with the ListUserPlans request.
  */
 public enum UserPlanInclusion {
-    PLAN_NAMES("planNames"),
+    PLAN_NAME("planName"),
     ;
 
     String inclusion;

--- a/src/test/java/com/smartsheet/api/sdktest/users/TestListUserPlans.java
+++ b/src/test/java/com/smartsheet/api/sdktest/users/TestListUserPlans.java
@@ -46,7 +46,7 @@ public class TestListUserPlans {
     private static final SeatType TEST_SEAT_TYPE = SeatType.MEMBER;
     private static final String TEST_SEAT_TYPE_LAST_CHANGED_AT = "2025-01-01T00:00:00.123456789Z";
     private static final String TEST_PROVISIONAL_EXPIRATION_DATE = "2026-12-13T12:17:52.525696Z";
-    private static final EnumSet<UserPlanInclusion> TEST_INCLUDES = EnumSet.of(UserPlanInclusion.PLAN_NAMES);
+    private static final EnumSet<UserPlanInclusion> TEST_INCLUDES = EnumSet.of(UserPlanInclusion.PLAN_NAME);
     private static final String TEST_PLAN_NAME = "Acme Corporation";
 
     @Test
@@ -68,7 +68,7 @@ public class TestListUserPlans {
         assertThat(receivedQueryParams.get("maxItems").getValues()).isEqualTo(List.of(Long.toString(TEST_MAX_ITEMS)));
         assertThat(receivedQueryParams.get("lastKey").getValues()).isEqualTo(List.of(TEST_LAST_KEY));
         assertThat(receivedQueryParams.get("displayContributorSeatType").getValues()).isEqualTo(List.of("true"));
-        assertThat(receivedQueryParams.get("include").getValues()).isEqualTo(List.of("planNames"));
+        assertThat(receivedQueryParams.get("include").getValues()).isEqualTo(List.of("planName"));
     }
 
     @Test

--- a/src/test/java/com/smartsheet/api/sdktest/users/TestListUserPlans.java
+++ b/src/test/java/com/smartsheet/api/sdktest/users/TestListUserPlans.java
@@ -25,11 +25,13 @@ import com.smartsheet.api.WiremockClientWrapper;
 import com.smartsheet.api.models.TokenPaginatedResult;
 import com.smartsheet.api.models.UserPlan;
 import com.smartsheet.api.models.enums.SeatType;
+import com.smartsheet.api.models.enums.UserPlanInclusion;
 import com.smartsheet.api.sdktest.Utils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,6 +46,8 @@ public class TestListUserPlans {
     private static final SeatType TEST_SEAT_TYPE = SeatType.MEMBER;
     private static final String TEST_SEAT_TYPE_LAST_CHANGED_AT = "2025-01-01T00:00:00.123456789Z";
     private static final String TEST_PROVISIONAL_EXPIRATION_DATE = "2026-12-13T12:17:52.525696Z";
+    private static final EnumSet<UserPlanInclusion> TEST_INCLUDES = EnumSet.of(UserPlanInclusion.PLAN_NAMES);
+    private static final String TEST_PLAN_NAME = "Acme Corporation";
 
     @Test
     void testListUserPlansGeneratedUrlIsCorrect() throws SmartsheetException {
@@ -55,7 +59,7 @@ public class TestListUserPlans {
         Smartsheet smartsheet = wrapper.getSmartsheet();
         WiremockClient wiremockClient = wrapper.getWiremockClient();
 
-        smartsheet.userResources().listUserPlans(TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, true);
+        smartsheet.userResources().listUserPlans(TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, true, TEST_INCLUDES);
         LoggedRequest wiremockRequest = wiremockClient.findWiremockRequest(requestId);
         String path = URI.create(wiremockRequest.getUrl()).getPath();
         Map<String, QueryParameter> receivedQueryParams = wiremockRequest.getQueryParams();
@@ -64,6 +68,7 @@ public class TestListUserPlans {
         assertThat(receivedQueryParams.get("maxItems").getValues()).isEqualTo(List.of(Long.toString(TEST_MAX_ITEMS)));
         assertThat(receivedQueryParams.get("lastKey").getValues()).isEqualTo(List.of(TEST_LAST_KEY));
         assertThat(receivedQueryParams.get("displayContributorSeatType").getValues()).isEqualTo(List.of("true"));
+        assertThat(receivedQueryParams.get("include").getValues()).isEqualTo(List.of("planNames"));
     }
 
     @Test
@@ -76,7 +81,7 @@ public class TestListUserPlans {
         Smartsheet smartsheet = wrapper.getSmartsheet();
 
         TokenPaginatedResult<UserPlan> response = smartsheet.userResources()
-                .listUserPlans(TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS);
+                .listUserPlans(TEST_USER_ID, TEST_LAST_KEY, TEST_MAX_ITEMS, null, TEST_INCLUDES);
 
         assertThat(response).isNotNull();
         assertThat(response.getLastKey()).isEqualTo(TEST_LAST_KEY);
@@ -84,12 +89,14 @@ public class TestListUserPlans {
 
         // Verify first plan (MEMBER)
         assertThat(response.getData().get(0).getPlanId()).isEqualTo(TEST_PLAN_ID);
+        assertThat(response.getData().get(0).getPlanName()).isEqualTo(TEST_PLAN_NAME);
         assertThat(response.getData().get(0).getSeatType()).isEqualTo(TEST_SEAT_TYPE);
         assertThat(response.getData().get(0).getSeatTypeLastChangedAt()).isEqualTo(TEST_SEAT_TYPE_LAST_CHANGED_AT);
         assertThat(response.getData().get(0).getProvisionalExpirationDate()).isEqualTo(TEST_PROVISIONAL_EXPIRATION_DATE);
         assertThat(response.getData().get(0).getIsInternal()).isFalse();
 
-        // Verify second plan (CONTRIBUTOR)
+        // Verify second plan (CONTRIBUTOR), which omits the optional planName
+        assertThat(response.getData().get(1).getPlanName()).isNull();
         assertThat(response.getData().get(1).getSeatType()).isEqualTo(SeatType.CONTRIBUTOR);
         assertThat(response.getData().get(1).getSeatTypeLastChangedAt()).isEqualTo(TEST_SEAT_TYPE_LAST_CHANGED_AT);
         assertThat(response.getData().get(1).getProvisionalExpirationDate()).isEqualTo(TEST_PROVISIONAL_EXPIRATION_DATE);
@@ -110,6 +117,7 @@ public class TestListUserPlans {
 
         assertThat(response).isNotNull();
         assertThat(response.getData().get(0).getPlanId()).isEqualTo(TEST_PLAN_ID);
+        assertThat(response.getData().get(0).getPlanName()).isNull();
         assertThat(response.getData().get(0).getSeatType()).isEqualTo(TEST_SEAT_TYPE);
         assertThat(response.getData().get(0).getSeatTypeLastChangedAt()).isNull();
         assertThat(response.getData().get(0).getProvisionalExpirationDate()).isNull();


### PR DESCRIPTION
# Pull Request

## Summary

`GET /2.0/users/{userId}/plans` gained an optional `include` query parameter whose only accepted value is `planName`, matching the response field it controls. When requested, each returned plan carries the name of the organization that owns it. This adds SDK support for it.

**New `listUserPlans` overload.** `UserResources.listUserPlans` gains a five-argument overload taking `EnumSet<UserPlanInclusion>`, serialized comma-separated via `QueryUtil.generateCommaSeparatedList` like every other `include` parameter in the SDK. The existing four-argument signature is **untouched and simply delegates** to the overload passing `null`, so source compatibility is preserved and existing callers need no changes.

**Omitting the parameter is byte-identical to today.** The `include` key is only added to the parameter map when `includes != null`, so callers on the original signature produce exactly the same request URL as before this change.

**New `planName` field on `UserPlan`.** It is optional and deserializes to `null` in two distinct cases: when the enrichment was not requested, and when the owning organization has no name. A `null` therefore does not by itself mean the enrichment was not requested, which the javadoc calls out.

### Design note

The inclusion enum follows existing precedent rather than introducing a new pattern: 23 inclusion enums already exist in `models/enums/`, and `listUsers` in this same interface already takes an `EnumSet<ListUserInclusion>`.

### Caching caveat

Organization names are cached server side for roughly four hours. A recently renamed organization may briefly report its previous name through this field. This is documented in the javadoc on both the overload and `UserPlan.getPlanName()` so callers are not surprised.

## Files changed

| File | Change |
|---|---|
| `src/main/java/com/smartsheet/api/UserResources.java` | Declares the new five-arg `listUserPlans` overload |
| `src/main/java/com/smartsheet/api/internal/UserResourcesImpl.java` | Implements the overload; original signature delegates to it |
| `src/main/java/com/smartsheet/api/models/UserPlan.java` | Adds the `planName` property with getter/setter |
| `src/main/java/com/smartsheet/api/models/enums/UserPlanInclusion.java` | New enum, single value `PLAN_NAME` -> `planName` |
| `src/test/java/com/smartsheet/api/sdktest/users/TestListUserPlans.java` | Asserts the query parameter and `planName` deserialization |
| `CHANGELOG.md` | Two bullets under Unreleased / Added |

## Testing

Run against the shared WireMock mappings from `smartsheet/smartsheet-sdk-tests` `mainline`, which now includes `planName` on the List User Plans all-properties mapping.

- `./gradlew sdkTest` - **181 tests, 179 passed, 0 failures, 2 skipped**
- `./gradlew test` - **662 tests, 661 passed, 0 failures, 1 skipped**
- `./gradlew clean build` - **BUILD SUCCESSFUL**

All 3 skips are pre-existing and unrelated to this change (`AutomationRulesTest.updateAutomationRule`, `SightsTest.copySight`, `UserResourcesImplTest.testPromoteAlternateEmail`).

Test coverage in `TestListUserPlans` asserts `include=planName` appears in the request query params, that `getPlanName()` returns `"Acme Corporation"` for the plan that has one, and that it is `null` both for a plan omitting it and in the required-properties case.

One note for reviewers: this change adds a fourth `checkstyleMain` violation, `MultipleStringLiterals` for the string `"include"` now appearing 3 times in `UserResourcesImpl.java`. The baseline on `mainline` is 3 violations and `checkstyleMain` allows up to 5, so the build still passes. Happy to extract a constant if you would prefer to keep the count flat.

## Checklist

* [x] Read the **[contribution guide](https://github.com/smartsheet/smartsheet-java-sdk/blob/mainline/ADVANCED.md)**
* [x] Successfully build your changes locally - Run `./gradlew clean build`
* [x] Include a title that clearly describes your changes and references relevant issues / backlog items
* [x] Include a summary of your changes
* [x] Include tests for your changes where possible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requesting plan names when listing user plans.
  * User plan results can now include a `planName` value when requested; it remains unavailable when not included.
  * Added documentation describing the new query option and response field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
