### PR TITLE
Prepare for release v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.4.0] - 2026-08-12
+
 ### Added
 - `Proof` model and `ProofType` enum
 - `proof` property on rows returned by `getSheet` and `getReport`

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 // The group name. This dictates the prefix our dependency will have once it's published.
 group = 'com.smartsheet'
 // The version. This will be added to the end of the Jar and all other resources that are created during the build.
-version = '4.3.0'
+version = '4.4.0'
 // The Java version:
 sourceCompatibility = '11'
 


### PR DESCRIPTION
Closes out the CHANGELOG for v4.4.0 and bumps the version in `build.gradle`.

Minor bump: the Unreleased section contains non-breaking additions.

### Added
- `Proof` model and `ProofType` enum
- `proof` property on rows returned by `getSheet` and `getReport`
- `PROOFS` inclusion value for `SheetInclusion`, `ReportInclusion`, and `RowInclusion`
- `ReportColumn.AddReportColumnBuilder` for constructing report columns
- Support for the `include` query parameter on GET /2.0/users/{userId}/plans via a new `UserResources.listUserPlans` overload, along with a `UserPlanInclusion` enum whose only value is `PLAN_NAME`
- `planName` property on `UserPlan`, populated when `PLAN_NAME` is requested

### Fixed
- `COMMENTER` value for `AccessLevel`, which previously deserialized to `null` on sheets, reports, workspaces, and shares. Fixes [smartsheet-csharp-sdk#218](https://github.com/smartsheet/smartsheet-csharp-sdk/issues/218)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 4.4.0.
  - Added a changelog entry dated August 12, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->