### PR TITLE
Java SDK for GET Data Classification Settings API

### DIFF
--- a/src/main/java/com/smartsheet/api/GovernanceResources.java
+++ b/src/main/java/com/smartsheet/api/GovernanceResources.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api;
+
+import com.smartsheet.api.models.DataClassificationSettings;
+
+/**
+ * This interface provides methods for Governance operations.
+ */
+public interface GovernanceResources {
+
+    /**
+     * Get the data classification settings for a plan.
+     *
+     * @param planId the ID of the plan
+     * @return the DataClassificationSettings
+     * @throws SmartsheetException if there is any other error during the operation
+     */
+    DataClassificationSettings getDataClassificationSettings(long planId) throws SmartsheetException;
+}

--- a/src/main/java/com/smartsheet/api/Smartsheet.java
+++ b/src/main/java/com/smartsheet/api/Smartsheet.java
@@ -204,4 +204,11 @@ public interface Smartsheet {
      * @return the asset share resources instance
      */
     AssetShareResources assetShareResources();
+
+    /**
+     * Returns the GovernanceResources instance that provides access to Governance resources
+     *
+     * @return the governance resources instance
+     */
+    GovernanceResources governanceResources();
 }

--- a/src/main/java/com/smartsheet/api/internal/GovernanceResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/GovernanceResourcesImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.internal;
+
+import com.smartsheet.api.GovernanceResources;
+import com.smartsheet.api.SmartsheetException;
+import com.smartsheet.api.internal.util.QueryUtil;
+import com.smartsheet.api.models.DataClassificationSettings;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is the implementation of GovernanceResources.
+ * <p>
+ * Thread Safety: This class is thread safe because it is immutable and its base class is thread safe.
+ */
+public class GovernanceResourcesImpl extends AbstractResources implements GovernanceResources {
+
+    /**
+     * Constructor.
+     *
+     * @param smartsheet the smartsheet
+     */
+    public GovernanceResourcesImpl(SmartsheetImpl smartsheet) {
+        super(smartsheet);
+    }
+
+    /**
+     * Get the data classification settings for a plan.
+     *
+     * @param planId the ID of the plan
+     * @return the DataClassificationSettings
+     * @throws SmartsheetException if there is any other error during the operation
+     */
+    @Override
+    public DataClassificationSettings getDataClassificationSettings(long planId) throws SmartsheetException {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("planId", planId);
+        return this.getResource(
+                "governance/data-classification/settings" + QueryUtil.generateUrl(null, parameters),
+                DataClassificationSettings.class
+        );
+    }
+}

--- a/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
@@ -21,6 +21,7 @@ import com.smartsheet.api.ContactResources;
 import com.smartsheet.api.EventResources;
 import com.smartsheet.api.FavoriteResources;
 import com.smartsheet.api.FolderResources;
+import com.smartsheet.api.GovernanceResources;
 import com.smartsheet.api.GroupResources;
 import com.smartsheet.api.HomeResources;
 import com.smartsheet.api.ImageUrlResources;
@@ -272,6 +273,15 @@ public class SmartsheetImpl implements Smartsheet {
      */
     private final AtomicReference<AssetShareResources> assetShares;
 
+    /**
+     * Represents the AtomicReference for GovernanceResources.
+     * <p>
+     * It will be initialized in constructor and will not change afterward. The underlying value will be initially set
+     * as null, and will be initialized to non-null at the first time it is accessed via corresponding getter, therefore
+     * effectively the underlying value is lazily created in a thread safe manner.
+     */
+    private final AtomicReference<GovernanceResources> governance;
+
     private static final String INVALID_OPERATION_FOR_CLASS = "Invalid operation for class ";
 
     /**
@@ -330,6 +340,7 @@ public class SmartsheetImpl implements Smartsheet {
         this.passthrough = new AtomicReference<>();
         this.events = new AtomicReference<>();
         this.assetShares = new AtomicReference<>();
+        this.governance = new AtomicReference<>();
     }
 
     /**
@@ -689,6 +700,18 @@ public class SmartsheetImpl implements Smartsheet {
             assetShares.compareAndSet(null, new AssetShareResourcesImpl(this));
         }
         return assetShares.get();
+    }
+
+    /**
+     * Returns the GovernanceResources instance that provides access to Governance resources.
+     *
+     * @return the governance resources
+     */
+    public GovernanceResources governanceResources() {
+        if (governance.get() == null) {
+            governance.compareAndSet(null, new GovernanceResourcesImpl(this));
+        }
+        return governance.get();
     }
 
     /**

--- a/src/main/java/com/smartsheet/api/models/ApproverEntry.java
+++ b/src/main/java/com/smartsheet/api/models/ApproverEntry.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import java.util.List;
+
+/**
+ * Represents an approver entry in downgrade approval settings.
+ */
+public class ApproverEntry {
+
+    private String type;
+    private List<Long> ids;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<Long> getIds() {
+        return ids;
+    }
+
+    public void setIds(List<Long> ids) {
+        this.ids = ids;
+    }
+}

--- a/src/main/java/com/smartsheet/api/models/ClassificationLabel.java
+++ b/src/main/java/com/smartsheet/api/models/ClassificationLabel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+/**
+ * Represents a single classification label.
+ */
+public class ClassificationLabel {
+
+    private String id;
+    private String name;
+    private String description;
+    private String color;
+    private Integer sensitivityOrder;
+    private Boolean isDefault;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public Integer getSensitivityOrder() {
+        return sensitivityOrder;
+    }
+
+    public void setSensitivityOrder(Integer sensitivityOrder) {
+        this.sensitivityOrder = sensitivityOrder;
+    }
+
+    public Boolean getIsDefault() {
+        return isDefault;
+    }
+
+    public void setIsDefault(Boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+}

--- a/src/main/java/com/smartsheet/api/models/DataClassificationSettings.java
+++ b/src/main/java/com/smartsheet/api/models/DataClassificationSettings.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import java.util.List;
+
+/**
+ * Represents the data classification settings for a plan.
+ */
+public class DataClassificationSettings {
+
+    private Long orgId;
+    private Long planId;
+    private Boolean isDisabled;
+    private String guidelinesUrl;
+    private Boolean allowManualChange;
+    private List<ClassificationLabel> labels;
+    private DowngradeApprovalSettings downgradeApprovalSettings;
+
+    public Long getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(Long orgId) {
+        this.orgId = orgId;
+    }
+
+    public Long getPlanId() {
+        return planId;
+    }
+
+    public void setPlanId(Long planId) {
+        this.planId = planId;
+    }
+
+    public Boolean getIsDisabled() {
+        return isDisabled;
+    }
+
+    public void setIsDisabled(Boolean isDisabled) {
+        this.isDisabled = isDisabled;
+    }
+
+    public String getGuidelinesUrl() {
+        return guidelinesUrl;
+    }
+
+    public void setGuidelinesUrl(String guidelinesUrl) {
+        this.guidelinesUrl = guidelinesUrl;
+    }
+
+    public Boolean getAllowManualChange() {
+        return allowManualChange;
+    }
+
+    public void setAllowManualChange(Boolean allowManualChange) {
+        this.allowManualChange = allowManualChange;
+    }
+
+    public List<ClassificationLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<ClassificationLabel> labels) {
+        this.labels = labels;
+    }
+
+    public DowngradeApprovalSettings getDowngradeApprovalSettings() {
+        return downgradeApprovalSettings;
+    }
+
+    public void setDowngradeApprovalSettings(DowngradeApprovalSettings downgradeApprovalSettings) {
+        this.downgradeApprovalSettings = downgradeApprovalSettings;
+    }
+}

--- a/src/main/java/com/smartsheet/api/models/DowngradeApprovalSettings.java
+++ b/src/main/java/com/smartsheet/api/models/DowngradeApprovalSettings.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import java.util.List;
+
+/**
+ * Represents the downgrade approval settings for data classification.
+ */
+public class DowngradeApprovalSettings {
+
+    private String mode;
+    private List<ApproverEntry> approvers;
+    private List<LabelApproverEntry> labelApprovers;
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public List<ApproverEntry> getApprovers() {
+        return approvers;
+    }
+
+    public void setApprovers(List<ApproverEntry> approvers) {
+        this.approvers = approvers;
+    }
+
+    public List<LabelApproverEntry> getLabelApprovers() {
+        return labelApprovers;
+    }
+
+    public void setLabelApprovers(List<LabelApproverEntry> labelApprovers) {
+        this.labelApprovers = labelApprovers;
+    }
+}

--- a/src/main/java/com/smartsheet/api/models/LabelApproverEntry.java
+++ b/src/main/java/com/smartsheet/api/models/LabelApproverEntry.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.models;
+
+import java.util.List;
+
+/**
+ * Represents a per-label approver entry in downgrade approval settings.
+ */
+public class LabelApproverEntry {
+
+    private String labelId;
+    private List<ApproverEntry> approvers;
+
+    public String getLabelId() {
+        return labelId;
+    }
+
+    public void setLabelId(String labelId) {
+        this.labelId = labelId;
+    }
+
+    public List<ApproverEntry> getApprovers() {
+        return approvers;
+    }
+
+    public void setApprovers(List<ApproverEntry> approvers) {
+        this.approvers = approvers;
+    }
+}

--- a/src/test/java/com/smartsheet/api/internal/GovernanceResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/GovernanceResourcesImplTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2025 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smartsheet.api.internal;
+
+import com.smartsheet.api.InvalidRequestException;
+import com.smartsheet.api.SmartsheetException;
+import com.smartsheet.api.internal.http.DefaultHttpClient;
+import com.smartsheet.api.models.DataClassificationSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GovernanceResourcesImplTest extends ResourcesImplBase {
+
+    private GovernanceResourcesImpl governanceResources;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        governanceResources = new GovernanceResourcesImpl(new SmartsheetImpl("http://localhost:9090/1.1/",
+                "accessToken", new DefaultHttpClient(), serializer));
+    }
+
+    // ── URL + query param ─────────────────────────────────────────────────────
+
+    @Test
+    void testGetDataClassificationSettings_urlAndQueryParam() throws IOException, SmartsheetException {
+        server.setResponseBody(new File("src/test/resources/getDataClassificationSettings.json"));
+
+        governanceResources.getDataClassificationSettings(41878788L);
+
+        String requestUrl = server.getLastRequestUrl();
+        assertThat(requestUrl).contains("/governance/data-classification/settings");
+        assertThat(requestUrl).contains("planId=41878788");
+    }
+
+    // ── APPROVAL_NEEDED mode (happy path) ─────────────────────────────────────
+
+    @Test
+    void testGetDataClassificationSettings_approvalNeededMode() throws IOException, SmartsheetException {
+        server.setResponseBody(new File("src/test/resources/getDataClassificationSettings.json"));
+
+        DataClassificationSettings settings = governanceResources.getDataClassificationSettings(41878788L);
+
+        assertThat(settings).isNotNull();
+        assertThat(settings.getOrgId()).isEqualTo(1244212L);
+        assertThat(settings.getPlanId()).isEqualTo(41878788L);
+        assertThat(settings.getIsDisabled()).isFalse();
+        assertThat(settings.getGuidelinesUrl()).isEqualTo("https://wiki.example.com/classification-guide");
+        assertThat(settings.getAllowManualChange()).isTrue();
+
+        assertThat(settings.getLabels()).hasSize(1);
+        assertThat(settings.getLabels().get(0).getId()).isEqualTo("3fa85f64-5717-4562-b3fc-2c963f66afa6");
+        assertThat(settings.getLabels().get(0).getName()).isEqualTo("Confidential");
+        assertThat(settings.getLabels().get(0).getDescription()).isEqualTo("Highly sensitive information");
+        assertThat(settings.getLabels().get(0).getColor()).isEqualTo("#FFE0E3");
+        assertThat(settings.getLabels().get(0).getSensitivityOrder()).isEqualTo(1);
+        assertThat(settings.getLabels().get(0).getIsDefault()).isFalse();
+
+        assertThat(settings.getDowngradeApprovalSettings()).isNotNull();
+        assertThat(settings.getDowngradeApprovalSettings().getMode()).isEqualTo("APPROVAL_NEEDED");
+        assertThat(settings.getDowngradeApprovalSettings().getApprovers()).hasSize(1);
+        assertThat(settings.getDowngradeApprovalSettings().getApprovers().get(0).getType()).isEqualTo("GROUPS");
+        assertThat(settings.getDowngradeApprovalSettings().getApprovers().get(0).getIds()).containsExactly(5001L, 5002L);
+        assertThat(settings.getDowngradeApprovalSettings().getLabelApprovers()).isNull();
+    }
+
+    // ── CUSTOM mode ───────────────────────────────────────────────────────────
+
+    @Test
+    void testGetDataClassificationSettings_customMode() throws IOException, SmartsheetException {
+        server.setResponseBody(new File("src/test/resources/getDataClassificationSettingsCustomMode.json"));
+
+        DataClassificationSettings settings = governanceResources.getDataClassificationSettings(41878788L);
+
+        assertThat(settings.getDowngradeApprovalSettings().getMode()).isEqualTo("CUSTOM");
+        // CUSTOM: no top-level approvers, only per-label approvers
+        assertThat(settings.getDowngradeApprovalSettings().getApprovers()).isNull();
+        assertThat(settings.getDowngradeApprovalSettings().getLabelApprovers()).hasSize(1);
+        assertThat(settings.getDowngradeApprovalSettings().getLabelApprovers().get(0).getLabelId())
+                .isEqualTo("4aa85f64-5717-4562-b3fc-2c963f66afa7");
+
+        var labelApprovers = settings.getDowngradeApprovalSettings().getLabelApprovers().get(0).getApprovers();
+        assertThat(labelApprovers).hasSize(2);
+        assertThat(labelApprovers.get(0).getType()).isEqualTo("USERS");
+        assertThat(labelApprovers.get(0).getIds()).containsExactly(7001L);
+        assertThat(labelApprovers.get(1).getType()).isEqualTo("WORKSPACE_ADMINS");
+        assertThat(labelApprovers.get(1).getIds()).isEmpty();
+    }
+
+    // ── NONE mode (required-only fields) ──────────────────────────────────────
+
+    @Test
+    void testGetDataClassificationSettings_noneMode() throws IOException, SmartsheetException {
+        server.setResponseBody("{\"orgId\":1244212,\"planId\":41878788,\"isDisabled\":false," +
+                "\"labels\":[{\"id\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\"name\":\"Confidential\"," +
+                "\"color\":\"#FFE0E3\",\"sensitivityOrder\":1,\"isDefault\":false}]," +
+                "\"downgradeApprovalSettings\":{\"mode\":\"NONE\"}}");
+
+        DataClassificationSettings settings = governanceResources.getDataClassificationSettings(41878788L);
+
+        assertThat(settings.getDowngradeApprovalSettings().getMode()).isEqualTo("NONE");
+        assertThat(settings.getDowngradeApprovalSettings().getApprovers()).isNull();
+        assertThat(settings.getDowngradeApprovalSettings().getLabelApprovers()).isNull();
+        assertThat(settings.getGuidelinesUrl()).isNull();
+        assertThat(settings.getAllowManualChange()).isNull();
+        assertThat(settings.getLabels().get(0).getDescription()).isNull();
+    }
+
+    // ── Disabled plan ─────────────────────────────────────────────────────────
+
+    @Test
+    void testGetDataClassificationSettings_disabledPlan() throws IOException, SmartsheetException {
+        server.setResponseBody(new File("src/test/resources/getDataClassificationSettingsDisabledPlan.json"));
+
+        DataClassificationSettings settings = governanceResources.getDataClassificationSettings(41878788L);
+
+        assertThat(settings.getIsDisabled()).isTrue();
+        assertThat(settings.getLabels()).isEmpty();
+        assertThat(settings.getGuidelinesUrl()).isNull();
+        assertThat(settings.getAllowManualChange()).isNull();
+        assertThat(settings.getDowngradeApprovalSettings().getMode()).isEqualTo("NONE");
+        assertThat(settings.getDowngradeApprovalSettings().getApprovers()).isNull();
+    }
+
+    // ── Error responses ───────────────────────────────────────────────────────
+
+    @Test
+    void testGetDataClassificationSettings_error400() {
+        server.setStatus(400);
+        server.setResponseBody("{\"errorCode\":1032,\"message\":\"Bad Request\"}");
+
+        assertThatThrownBy(() -> governanceResources.getDataClassificationSettings(41878788L))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void testGetDataClassificationSettings_error404() {
+        server.setStatus(404);
+        server.setResponseBody("{\"errorCode\":1006,\"message\":\"Not Found\"}");
+
+        assertThatThrownBy(() -> governanceResources.getDataClassificationSettings(99999L))
+                .isInstanceOf(SmartsheetException.class);
+    }
+
+    @Test
+    void testGetDataClassificationSettings_error403() {
+        server.setStatus(403);
+        server.setResponseBody("{\"errorCode\":1004,\"message\":\"You are not authorized to perform this action.\"}");
+
+        assertThatThrownBy(() -> governanceResources.getDataClassificationSettings(41878788L))
+                .isInstanceOf(SmartsheetException.class);
+    }
+
+    @Test
+    void testGetDataClassificationSettings_error500() {
+        server.setStatus(500);
+        server.setResponseBody("{\"errorCode\":1500,\"message\":\"Internal Server Error\"}");
+
+        assertThatThrownBy(() -> governanceResources.getDataClassificationSettings(41878788L))
+                .isInstanceOf(SmartsheetException.class);
+    }
+}

--- a/src/test/java/com/smartsheet/api/internal/GovernanceResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/GovernanceResourcesImplTest.java
@@ -153,15 +153,6 @@ class GovernanceResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    void testGetDataClassificationSettings_error404() {
-        server.setStatus(404);
-        server.setResponseBody("{\"errorCode\":1006,\"message\":\"Not Found\"}");
-
-        assertThatThrownBy(() -> governanceResources.getDataClassificationSettings(99999L))
-                .isInstanceOf(SmartsheetException.class);
-    }
-
-    @Test
     void testGetDataClassificationSettings_error403() {
         server.setStatus(403);
         server.setResponseBody("{\"errorCode\":1004,\"message\":\"You are not authorized to perform this action.\"}");

--- a/src/test/java/com/smartsheet/api/internal/LocalIntegrationTest.java
+++ b/src/test/java/com/smartsheet/api/internal/LocalIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.smartsheet.api.internal;
+
+import com.smartsheet.api.models.DataClassificationSettings;
+import com.smartsheet.api.internal.http.DefaultHttpClient;
+import com.smartsheet.api.internal.json.JacksonJsonSerializer;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * Run manually against local SmarGate + DCS:
+ *
+ *   ./gradlew test --tests "com.smartsheet.api.internal.LocalIntegrationTest"
+ *
+ * Prerequisites:
+ *   - DCS on localhost:8080
+ *   - SmarGate on localhost:8081 (local-integration profile)
+ */
+@Disabled("Local integration test — remove @Disabled to run manually")
+class LocalIntegrationTest {
+
+    private static final long MASKED_PLAN_ID = 1148023251199876L; // raw 41878788
+
+    @Test
+    void getDataClassificationSettings_localStack() throws Exception {
+        SmartsheetImpl smartsheet = new SmartsheetImpl(
+                "http://localhost:8081/2.0/",
+                "dummy",
+                new DefaultHttpClient(),
+                new JacksonJsonSerializer()
+        );
+
+        // Subclass in the same package to access the package-private createHeaders(),
+        // and inject the internal headers that SmarGate's auth proxy normally sets.
+        GovernanceResourcesImpl governance = new GovernanceResourcesImpl(smartsheet) {
+            @Override
+            Map<String, String> createHeaders() {
+                Map<String, String> headers = super.createHeaders();
+                headers.put("x-smar-sc-actor-org-id", "1001");
+                headers.put("x-smar-sc-actor-id", "9999");
+                headers.put("X-Client-DN", "CN=api.governance.a.dev.smar.cloud");
+                return headers;
+            }
+        };
+
+        DataClassificationSettings settings = governance.getDataClassificationSettings(MASKED_PLAN_ID);
+
+        System.out.println("orgId:    " + settings.getOrgId());
+        System.out.println("planId:   " + settings.getPlanId());
+        System.out.println("disabled: " + settings.getIsDisabled());
+        System.out.println("labels:   " + settings.getLabels().size());
+        settings.getLabels().forEach(l ->
+                System.out.printf("  [%d] %s  color=%s%n",
+                        l.getSensitivityOrder(), l.getName(), l.getColor())
+        );
+        System.out.println("mode:     " + settings.getDowngradeApprovalSettings().getMode());
+    }
+}

--- a/src/test/resources/getDataClassificationSettings.json
+++ b/src/test/resources/getDataClassificationSettings.json
@@ -1,0 +1,21 @@
+{
+  "orgId": 1244212,
+  "planId": 41878788,
+  "isDisabled": false,
+  "guidelinesUrl": "https://wiki.example.com/classification-guide",
+  "allowManualChange": true,
+  "labels": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "name": "Confidential",
+      "description": "Highly sensitive information",
+      "color": "#FFE0E3",
+      "sensitivityOrder": 1,
+      "isDefault": false
+    }
+  ],
+  "downgradeApprovalSettings": {
+    "mode": "APPROVAL_NEEDED",
+    "approvers": [{"type": "GROUPS", "ids": [5001, 5002]}]
+  }
+}

--- a/src/test/resources/getDataClassificationSettingsCustomMode.json
+++ b/src/test/resources/getDataClassificationSettingsCustomMode.json
@@ -1,0 +1,37 @@
+{
+  "orgId": 1244212,
+  "planId": 41878788,
+  "isDisabled": false,
+  "guidelinesUrl": "https://wiki.example.com/classification-guide",
+  "allowManualChange": true,
+  "labels": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "name": "Confidential",
+      "description": "Highly sensitive information",
+      "color": "#FFE0E3",
+      "sensitivityOrder": 1,
+      "isDefault": false
+    },
+    {
+      "id": "4aa85f64-5717-4562-b3fc-2c963f66afa7",
+      "name": "Internal",
+      "description": "For internal use only",
+      "color": "#E0F0FF",
+      "sensitivityOrder": 2,
+      "isDefault": true
+    }
+  ],
+  "downgradeApprovalSettings": {
+    "mode": "CUSTOM",
+    "labelApprovers": [
+      {
+        "labelId": "4aa85f64-5717-4562-b3fc-2c963f66afa7",
+        "approvers": [
+          { "type": "USERS", "ids": [7001] },
+          { "type": "WORKSPACE_ADMINS", "ids": [] }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/getDataClassificationSettingsDisabledPlan.json
+++ b/src/test/resources/getDataClassificationSettingsDisabledPlan.json
@@ -1,0 +1,9 @@
+{
+  "orgId": 1244212,
+  "planId": 41878788,
+  "isDisabled": true,
+  "labels": [],
+  "downgradeApprovalSettings": {
+    "mode": "NONE"
+  }
+}


### PR DESCRIPTION
# Pull Request

  ## Summary

  Adds `GovernanceResources` with `getDataClassificationSettings(long planId)` to support the new `GET /2.0/governance/data-classification/settings?planId=` public API endpoint.

  **New files:**
  - `GovernanceResources.java` — interface
  - `GovernanceResourcesImpl.java` — implementation; builds `?planId=` query param via `QueryUtil.generateUrl`
  - `DataClassificationSettings.java`, `ClassificationLabel.java`, `DowngradeApprovalSettings.java`, `ApproverEntry.java`, `LabelApproverEntry.java` — response model POJOs
  - `GovernanceResourcesImplTest.java` — 9 unit tests covering URL/query param, all downgrade modes (NONE/APPROVAL_NEEDED/CUSTOM), disabled plan, and 400/403/404/500 errors

  **Modified files:**
  - `Smartsheet.java` — added `governanceResources()` declaration
  - `SmartsheetImpl.java` — added lazy-init `GovernanceResources` field

  ## Checklist
  * [x] Read the **[contribution guide](https://github.com/smartsheet/smartsheet-java-sdk/blob/mainline/ADVANCED.md)**
  * [x] Successfully build your changes locally - Run `./gradlew clean build`
  * [x] Include a title that clearly describes your changes and references relevant issues / backlog items
  * [x] Include a summary of your changes
  * [x] Include tests for your changes where possible